### PR TITLE
fix(website): prevent animation re-renders

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -11,10 +11,10 @@
 		"build:assets": "bun run build:demo-playground && bun run build:mdx-content && bun run build:panda:codegen && bun run build:panda:css",
 		"prebuild": "bun run build:assets",
 		"build": "next build --webpack",
-		"dev:next": "next dev --webpack --port 3000",
-		"dev:next:turbopack": "next dev --turbopack --port 3000",
+		"dev:next": "next dev --webpack --port ${PORT:-3000}",
+		"dev:next:turbopack": "next dev --turbopack --port ${PORT:-3000}",
 		"dev": "bun run build:assets && concurrently -n mdx,panda,next -c blue,magenta,green \"bun scripts/build-mdx-content.ts --watch\" \"bun x panda --watch\" \"bun run dev:next\"",
-		"start": "next start --port 3000",
+		"start": "next start --port ${PORT:-3000}",
 		"deploy": "bun run build",
 		"test": "bun test testing",
 		"typecheck": "bun run build:assets && bun run test && tsc --noEmit"

--- a/website/package.json
+++ b/website/package.json
@@ -11,10 +11,10 @@
 		"build:assets": "bun run build:demo-playground && bun run build:mdx-content && bun run build:panda:codegen && bun run build:panda:css",
 		"prebuild": "bun run build:assets",
 		"build": "next build --webpack",
-		"dev:next": "next dev --webpack --port ${PORT:-3000}",
-		"dev:next:turbopack": "next dev --turbopack --port ${PORT:-3000}",
+		"dev:next": "next dev --webpack --port 3000",
+		"dev:next:turbopack": "next dev --turbopack --port 3000",
 		"dev": "bun run build:assets && concurrently -n mdx,panda,next -c blue,magenta,green \"bun scripts/build-mdx-content.ts --watch\" \"bun x panda --watch\" \"bun run dev:next\"",
-		"start": "next start --port ${PORT:-3000}",
+		"start": "next start --port 3000",
 		"deploy": "bun run build",
 		"test": "bun test testing",
 		"typecheck": "bun run build:assets && bun run test && tsc --noEmit"

--- a/website/src/site/NotionCubeLogo.tsx
+++ b/website/src/site/NotionCubeLogo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { css, cx } from "../styled-system/css";
 
 const VIEWPORT_W = 25;
@@ -195,12 +195,12 @@ function viewportRowsToGrid(rows: readonly string[]): string[][] {
 	);
 }
 
-export function NotionCubeLogo({
+	export function NotionCubeLogo({
 		animate = true,
 		viewportRows,
 		fixedHero = false,
 	}: NotionCubeLogoProps) {
-		const [frame, setFrame] = useState(0);
+		const preRef = useRef<HTMLPreElement>(null);
 		const [reduceMotion, setReduceMotion] = useState(false);
 
 		useEffect(() => {
@@ -216,26 +216,32 @@ export function NotionCubeLogo({
 		}, [animate]);
 
 		useEffect(() => {
-			if (reduceMotion) {
+			if (reduceMotion || !animate) {
 				return;
 			}
+			let frame = 0;
 			const id = window.setInterval(() => {
-				setFrame((n) => (n + 1) % FRAME_COUNT);
+				frame = (frame + 1) % FRAME_COUNT;
+				if (preRef.current) {
+					preRef.current.textContent = PRECOMPUTED_DISPLAY[frame] ?? PRECOMPUTED_DISPLAY[0];
+				}
 			}, 90);
 			return () => window.clearInterval(id);
-		}, [reduceMotion]);
+		}, [reduceMotion, animate]);
 
 		const staticText = viewportRows
 			? buildMonitorLines(viewportRowsToGrid(viewportRows)).join("\n")
 			: PRECOMPUTED_DISPLAY[0];
 
-		const text =
+		const initialText =
 			reduceMotion || !animate
 				? staticText
-				: (PRECOMPUTED_DISPLAY[frame] ?? PRECOMPUTED_DISPLAY[0]);
+				: PRECOMPUTED_DISPLAY[0];
 
 		const pre = (
-			<pre className={cx(preClass, fixedHero && fixedHeroPreClass)}>{text}</pre>
+			<pre ref={preRef} className={cx(preClass, fixedHero && fixedHeroPreClass)}>
+				{initialText}
+			</pre>
 		);
 
 		if (fixedHero) {

--- a/website/src/site/NotionCubeLogo.tsx
+++ b/website/src/site/NotionCubeLogo.tsx
@@ -202,6 +202,7 @@ function viewportRowsToGrid(rows: readonly string[]): string[][] {
 	}: NotionCubeLogoProps) {
 		const preRef = useRef<HTMLPreElement>(null);
 		const [reduceMotion, setReduceMotion] = useState(false);
+		const shouldAnimate = animate && !reduceMotion;
 
 		useEffect(() => {
 			if (!animate) {
@@ -216,7 +217,7 @@ function viewportRowsToGrid(rows: readonly string[]): string[][] {
 		}, [animate]);
 
 		useEffect(() => {
-			if (reduceMotion || !animate) {
+			if (!shouldAnimate) {
 				return;
 			}
 			let frame = 0;
@@ -227,20 +228,20 @@ function viewportRowsToGrid(rows: readonly string[]): string[][] {
 				}
 			}, 90);
 			return () => window.clearInterval(id);
-		}, [reduceMotion, animate]);
+		}, [shouldAnimate]);
 
 		const staticText = viewportRows
 			? buildMonitorLines(viewportRowsToGrid(viewportRows)).join("\n")
 			: PRECOMPUTED_DISPLAY[0];
 
-		const initialText =
-			reduceMotion || !animate
+		const text =
+			!shouldAnimate
 				? staticText
 				: PRECOMPUTED_DISPLAY[0];
 
 		const pre = (
 			<pre ref={preRef} className={cx(preClass, fixedHero && fixedHeroPreClass)}>
-				{initialText}
+				{text}
 			</pre>
 		);
 


### PR DESCRIPTION
## Summary
- Refactored `NotionCubeLogo` animation to use `useRef` and direct DOM mutation (`textContent`) instead of React `useState`, preventing constant re-renders of the entire page.

# Before
<img width="2560" height="974" alt="before-site" src="https://github.com/user-attachments/assets/b1224a98-219f-4998-b759-54642a8d9d58" />

# After
<img width="2560" height="1116" alt="after-site" src="https://github.com/user-attachments/assets/ee75d472-84e0-46f5-9b0e-1f01fdbc27a3" />

