### PR TITLE
Stabilize imports and emit TS-only generated modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,32 @@
 A lightweight TypeScript [Notion API](https://developers.notion.com/) wrapper that aims to improve interactions with databases and custom agents, by leveraging static schema types
 
 ## Key Features
+
 - Type inference when interacting with databases (e.g, `add` and `query`)
 - Sync remote schema changes in single command
 - Quickly start/resume chat streams with your agents
 - Access exported property values, schemas, and types
 - Logs console warnings when local vs remote schema drift is detected
 
-
 ## Installation
+
 ```bash
-bun add @haustle/notion-orm
+npm install @haustle/notion-orm
+# or: pnpm add / yarn add / bun add @haustle/notion-orm
 ```
 
-After upgrading the package, run **`bun notion sync`** so generated files under **`notion/`** stay in sync with the version you installed (stale codegen can break at runtime when imports from the ORM package change). In app code, prefer **`import { NotionORM } from "./notion/"`** — the directory import resolves to `index.ts`, so you do not need to spell **`index`**.
+The CLI is installed as the `**notion**` binary and runs on **Node.js 18+** (the published shebang is `node`). After upgrading the package, run `**npx notion sync`** (or `**pnpm exec notion sync**`, `**yarn notion sync**`, `**bunx notion sync**`) so generated files under `**notion/**` stay in sync with the version you installed (stale codegen can break at runtime when imports from the ORM package change). In app code, prefer `**import { NotionORM } from "./notion/"**` — the directory import resolves to `index.ts`, so you do not need to spell `**index**`.
 
-Generated database and agent modules live in your app's local **`./notion/`** folder after `notion sync`; import those relative files directly if you need a generated factory outside the `NotionORM` wrapper.
+**Config file:** use `**notion.config.js`** or `**notion.config.mjs**` if you run the CLI with plain Node. `**notion.config.ts**` is supported when your runtime can load TypeScript (for example Bun or a project using a TS loader); otherwise compile the config or use JavaScript.
+
+Generated database and agent modules live in your app's local `**./notion/**` folder after `notion sync`; import those relative files directly if you need a generated factory outside the `NotionORM` wrapper.
 
 # Quick start
 
 Initialize config from your project root (recommended):
 
 ```bash
-bun notion init
+npx notion init
 ```
 
 Generated config shape:
@@ -54,19 +58,19 @@ export default NotionConfig;
 Add new database to track and generate static types (ex. how to find ID [here](https://developers.notion.com/guides/data-apis/working-with-databases#adding-pages-to-a-database) )
 
 ```bash
-bun notion add <database-id>
+npx notion add <database-id>
 ```
-
 
 ### Adding agents (paid feature)
 
 Agent support requires the [Notion Agents SDK](https://github.com/makenotion/notion-agents-sdk-js), which is **currently in alpha** and not published to npm. Because of this, a one-command setup handles the entire download-and-install flow for you:
 
 ```bash
-bun notion setup-agents-sdk
+npx notion setup-agents-sdk
 ```
 
 **What this does:**
+
 1. Clones the SDK repository into a local cache (`node_modules/.cache/.notion-agents-sdk`)
 2. Installs the SDK's dependencies and builds it
 3. Adds the built `@notionhq/agents-client` package to your project
@@ -76,8 +80,8 @@ After setup, run `notion sync` to generate agent types. Agents linked to your in
 **Updating:** When the upstream SDK receives changes, rerun the same command. It pulls the latest from the cached clone, rebuilds, and reinstalls:
 
 ```bash
-bun notion setup-agents-sdk
-bun notion sync
+npx notion setup-agents-sdk
+npx notion sync
 ```
 
 If you have not run the setup command, `notion sync` will skip agent generation and only produce database types. Once the SDK is published to npm, this step will no longer be necessary.
@@ -89,10 +93,11 @@ Learn more about [Custom Agents](https://www.notion.com/help/custom-agents) in t
 Fetch/refresh database schemas. If the agents SDK is installed, also syncs custom agents.
 
 ```bash
-bun notion sync
+npx notion sync
 ```
 
 ## Basic examples
+
 ### Create page in a database
 
 ```ts
@@ -136,6 +141,7 @@ const books = await notion.databases.books.findMany({
 ```
 
 ### Chat with agent
+
 ```ts
 const chat = await notion.agents.helpBot.chat({message: "Is the company closed today"})
 await notion.agents.helpBot.pollThread(chat.threadId)
@@ -143,7 +149,6 @@ const messages = await notion.agents.helpBot.getMessages(chat.threadId, {
   role: "agent",
 });
 ```
-
 
 ### Chat with agent (stream)
 
@@ -157,10 +162,9 @@ const thread = await notion.agents.helpBot.chatStream({
 
 # Implementation
 
-
 ### Client setup
 
-Create a single ORM instance with your Notion integration key. Import from the generated **`notion/`** folder (directory specifier → `index`):
+Create a single ORM instance with your Notion integration key. Import from the generated `**notion/**` folder (directory specifier → `index`):
 
 ```ts
 import { NotionORM } from "./notion/";
@@ -314,9 +318,8 @@ const nextTurn = await notion.agents.yourAgentName.chat({
 
 #### Streaming patterns
 
-
-
 How to start a new chat stream (pass `threadId` to resume):
+
 ```ts
 import { AgentClient } from "@haustle/notion-orm";
 
@@ -334,99 +337,107 @@ console.log("Thread ID:", thread.threadId);
 console.log("Final:", finalResponse);
 ```
 
-
-
-
-
 See [API Reference](#api-reference) for full method signatures, `ThreadInfo` shape, and message schemas.
 
 # API Reference
 
 ## Runtime access (detailed)
 
-| runtime property   | type                             | description                                                    | go deeper                                                            |
-| ------------------ | -------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `notion.databases` | `Record<string, DatabaseClient>` | Generated database client map keyed by camelCase database name | [Adding](#adding), [Querying](#querying)                             |
+
+| runtime property   | type                             | description                                                    | go deeper                                          |
+| ------------------ | -------------------------------- | -------------------------------------------------------------- | -------------------------------------------------- |
+| `notion.databases` | `Record<string, DatabaseClient>` | Generated database client map keyed by camelCase database name | [Adding](#adding), [Querying](#querying)           |
 | `notion.agents`    | `Record<string, AgentClient>`    | Generated agent client map keyed by camelCase agent name       | [Agents](#agents), [Agent methods](#agent-methods) |
+
 
 ## Database client methods
 
-| member                       | kind     | description                                                   | go deeper                                                                              |
-| ---------------------------- | -------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `id`                         | property | Notion data source ID used by this client instance            | -                                                                                      |
-| `name`                       | property | Human-readable database name captured during generation       | -                                                                                      |
-| `findMany({ where?, sortBy?, size?, select?, omit?, stream?, after? })` | method   | Queries database pages with typed filters, projection, pagination, or streaming | [Querying](#querying), [Supported database properties](#supported-database-properties) |
-| `findFirst({ where?, sortBy?, select?, omit? })` | method | Returns the first matching row or `null` | [Querying](#querying) |
-| `findUnique({ where: { id }, select?, omit? })` | method | Fetches a row by page ID with optional projection | [Querying](#querying) |
-| `create({ properties, icon?, cover?, markdown? })` | method | Creates a page with optional [markdown body content](https://developers.notion.com/guides/data-apis/working-with-markdown-content#block-type-support) | [Adding](#adding), [Markdown](#adding-page-content-with-markdown) |
+
+| member                                                                  | kind     | description                                                                                                                                           | go deeper                                                                              |
+| ----------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `id`                                                                    | property | Notion data source ID used by this client instance                                                                                                    | -                                                                                      |
+| `name`                                                                  | property | Human-readable database name captured during generation                                                                                               | -                                                                                      |
+| `findMany({ where?, sortBy?, size?, select?, omit?, stream?, after? })` | method   | Queries database pages with typed filters, projection, pagination, or streaming                                                                       | [Querying](#querying), [Supported database properties](#supported-database-properties) |
+| `findFirst({ where?, sortBy?, select?, omit? })`                        | method   | Returns the first matching row or `null`                                                                                                              | [Querying](#querying)                                                                  |
+| `findUnique({ where: { id }, select?, omit? })`                         | method   | Fetches a row by page ID with optional projection                                                                                                     | [Querying](#querying)                                                                  |
+| `create({ properties, icon?, cover?, markdown? })`                      | method   | Creates a page with optional [markdown body content](https://developers.notion.com/guides/data-apis/working-with-markdown-content#block-type-support) | [Adding](#adding), [Markdown](#adding-page-content-with-markdown)                      |
+
 
 ## Agent methods
 
-| member                                           | kind     | description                                           | go deeper                                                            |
-| ------------------------------------------------ | -------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| `id`                                             | property | Notion agent ID used by this client instance          | -                                                                    |
-| `name`                                           | property | Human-readable agent name                             | -                                                                    |
-| `icon`                                           | property | Normalized agent icon metadata (or `null`)            | -                                                                    |
-| `listThreads()`                                  | method   | Lists recent threads with `id`, `title`, and `status` | [Thread response shapes](#thread-response-shapes)                    |
-| `getThreadInfo(threadId)`                        | method   | Fetches a single thread record                        | [Thread response shapes](#thread-response-shapes)                    |
-| `getThreadTitle(threadId)`                       | method   | Convenience helper to fetch just the thread title     | [Thread response shapes](#thread-response-shapes)                    |
-| `chat({ message, threadId? })`                   | method   | Sends a message and creates/resumes a thread          | [Agents](#agents), [Thread response shapes](#thread-response-shapes) |
-| `chatStream({ message, threadId?, onMessage? })` | method   | Streams messages and returns final `ThreadInfo`       | [Agents](#agents), [Thread response shapes](#thread-response-shapes) |
-| `getMessages(threadId, { role? })`               | method   | Gets full (or role-filtered) message history          | [Thread response shapes](#thread-response-shapes)                    |
-| `pollThread(threadId, options?)`                 | method   | Polls until thread processing completes               | [Thread response shapes](#thread-response-shapes)                    |
-| `AgentClient.getAgentResponse(threadInfo)`       | method   | Extract combined plain-text agent output from a streamed thread | [Thread response shapes](#thread-response-shapes)             |
+
+| member                                           | kind     | description                                                     | go deeper                                                            |
+| ------------------------------------------------ | -------- | --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `id`                                             | property | Notion agent ID used by this client instance                    | -                                                                    |
+| `name`                                           | property | Human-readable agent name                                       | -                                                                    |
+| `icon`                                           | property | Normalized agent icon metadata (or `null`)                      | -                                                                    |
+| `listThreads()`                                  | method   | Lists recent threads with `id`, `title`, and `status`           | [Thread response shapes](#thread-response-shapes)                    |
+| `getThreadInfo(threadId)`                        | method   | Fetches a single thread record                                  | [Thread response shapes](#thread-response-shapes)                    |
+| `getThreadTitle(threadId)`                       | method   | Convenience helper to fetch just the thread title               | [Thread response shapes](#thread-response-shapes)                    |
+| `chat({ message, threadId? })`                   | method   | Sends a message and creates/resumes a thread                    | [Agents](#agents), [Thread response shapes](#thread-response-shapes) |
+| `chatStream({ message, threadId?, onMessage? })` | method   | Streams messages and returns final `ThreadInfo`                 | [Agents](#agents), [Thread response shapes](#thread-response-shapes) |
+| `getMessages(threadId, { role? })`               | method   | Gets full (or role-filtered) message history                    | [Thread response shapes](#thread-response-shapes)                    |
+| `pollThread(threadId, options?)`                 | method   | Polls until thread processing completes                         | [Thread response shapes](#thread-response-shapes)                    |
+| `AgentClient.getAgentResponse(threadInfo)`       | method   | Extract combined plain-text agent output from a streamed thread | [Thread response shapes](#thread-response-shapes)                    |
+
 
 ## Generated exports
 
-| import path                                    | what you get                                                                                                                                                                 | when to use                                                  |
-| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `./notion/` (relative)                         | `NotionORM` class (generated entry; same as `./notion/index` but shorter)                                                                                                    | Typical app code after **`notion sync`**                     |
-| `./notion/databases/<DatabaseName>.js`  | `<DatabaseName>(auth)` factory, `PageSchema`, `CreateSchema`, `QuerySchema`, generated Zod schema, generated option tuples (for select/status/multi-select), schema/type aliases | Script-level direct DB usage without the `NotionORM` wrapper |
-| `./notion/agents/<AgentName>.js` | `<AgentName>(auth)` factory that returns an `AgentClient` (PascalCase export; registry keys on `notion.agents` stay camelCase)                                                | Script-level direct agent usage                              |
-| `./notion/databases/index.js`                 | `databases` barrel object (all database factories)                                                                                                                           | Dynamic database selection or custom registry wiring         |
-| `./notion/agents/index.js`             | `agents` barrel object (all agent factories)                                                                                                                                 | Dynamic agent selection or custom registry wiring            |
+
+| import path                            | what you get                                                                                                                                                                     | when to use                                                  |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `./notion/` (relative)                 | `NotionORM` class (generated entry; same as `./notion/index` but shorter)                                                                                                        | Typical app code after `**notion sync**`                     |
+| `./notion/databases/<DatabaseName>.js` | `<DatabaseName>(auth)` factory, `PageSchema`, `CreateSchema`, `QuerySchema`, generated Zod schema, generated option tuples (for select/status/multi-select), schema/type aliases | Script-level direct DB usage without the `NotionORM` wrapper |
+| `./notion/agents/<AgentName>.js`       | `<AgentName>(auth)` factory that returns an `AgentClient` (PascalCase export; registry keys on `notion.agents` stay camelCase)                                                   | Script-level direct agent usage                              |
+| `./notion/databases/index.js`          | `databases` barrel object (all database factories)                                                                                                                               | Dynamic database selection or custom registry wiring         |
+| `./notion/agents/index.js`             | `agents` barrel object (all agent factories)                                                                                                                                     | Dynamic agent selection or custom registry wiring            |
+
 
 ## Thread response shapes
 
 `chatStream(...)` returns `ThreadInfo` with the following properties:
 
-| ThreadInfo property | type                                                 | description                                              | example                                                                                            |
-| ------------------- | ---------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `threadId`          | `string`                                             | Stable thread identifier used to continue a conversation | `"1f4e6f4a-5b58-4d91-a7fc-2f5f2a0f6bb1"`                                                           |
-| `agentId`           | `string`                                             | Agent identifier that produced the response              | `"2c3c495da03c8078b95500927f02d213"`                                                               |
-| `messages`          | `Array<{ role: "user" | "agent"; content: string }>` | Full message history currently available in the thread   | `[{ role: "user", content: "Plan meals" }, { role: "agent", content: "Here is a 3-day plan..." }]` |
+
+| ThreadInfo property | type                  | description                                              | example                                                |
+| ------------------- | --------------------- | -------------------------------------------------------- | ------------------------------------------------------ |
+| `threadId`          | `string`              | Stable thread identifier used to continue a conversation | `"1f4e6f4a-5b58-4d91-a7fc-2f5f2a0f6bb1"`               |
+| `agentId`           | `string`              | Agent identifier that produced the response              | `"2c3c495da03c8078b95500927f02d213"`                   |
+| `messages`          | `Array<{ role: "user" | "agent"; content: string }>`                             | Full message history currently available in the thread |
+
 
 `messages` item shape:
 
-| message property | type               | description                |
-| ---------------- | ------------------ | -------------------------- |
-| `role`           | `user` | `agent` (`string`) | Message author             |
-| `content`        | `string`           | Plain text message content |
+
+| message property | type     | description                |
+| ---------------- | -------- | -------------------------- |
+| `role`           | `user`   | `agent` (`string`)         |
+| `content`        | `string` | Plain text message content |
+
 
 ## Supported database properties
 
 
-| property_type      | expected returned shape                                              | example value                                 |
-| ------------------ | -------------------------------------------------------------------- | --------------------------------------------- |
-| `title`            | `string`                                                             | `"The Dream Machine"`                         |
-| `rich_text`        | `string`                                                      | `"Long-form notes from the page"`             |
-| `number`           | `number`                                                      | `460`                                         |
-| `date`             | `{ start: string; end: string }`                             | `{ start: "2026-03-01", end: "2026-03-02" }`  |
-| `status`           | `string`                                                      | `"In progress"`                               |
-| `select`           | `string`                                                      | `"Non-fiction"`                               |
-| `multi_select`     | `string[]`                                                    | `["Sci-Fi", "Biography"]`                     |
-| `checkbox`         | `boolean`                                                            | `true`                                        |
-| `email`            | `string`                                                      | `"tyrus@haustle.studio"`                      |
-| `phone_number`     | `string`                                                      | `"0000000000"`                                |
-| `url`              | `string`                                                      | `"https://developers.notion.com/"`            |
-| `files`            | `Array<{ name: string; url: string }>`                               | `[{ name: "brief.pdf", url: "https://..." }]` |
-| `people`           | `string[]`                                                           | `["1f4e6f4a-5b58-4d91-a7fc-2f5f2a0f6bb1"]`    |
-| `relation`         | `string[]`                                                           | `["6f7f9cbf-8d45-48f8-a194-661e73f7f5d9"]`    |
-| `created_by`       | `string`                                                      | `"Ada Lovelace"`                              |
-| `last_edited_by`   | `string`                                                      | `"user_123"`                                  |
-| `created_time`     | `string`                                                      | `"2026-03-01T10:30:00.000Z"`                  |
-| `last_edited_time` | `string`                                                      | `"2026-03-01T13:15:00.000Z"`                  |
-| `unique_id`        | `string`                                                      | `"TASK-42"`                                   |
+| property_type      | expected returned shape                | example value                                 |
+| ------------------ | -------------------------------------- | --------------------------------------------- |
+| `title`            | `string`                               | `"The Dream Machine"`                         |
+| `rich_text`        | `string`                               | `"Long-form notes from the page"`             |
+| `number`           | `number`                               | `460`                                         |
+| `date`             | `{ start: string; end: string }`       | `{ start: "2026-03-01", end: "2026-03-02" }`  |
+| `status`           | `string`                               | `"In progress"`                               |
+| `select`           | `string`                               | `"Non-fiction"`                               |
+| `multi_select`     | `string[]`                             | `["Sci-Fi", "Biography"]`                     |
+| `checkbox`         | `boolean`                              | `true`                                        |
+| `email`            | `string`                               | `"tyrus@haustle.studio"`                      |
+| `phone_number`     | `string`                               | `"0000000000"`                                |
+| `url`              | `string`                               | `"https://developers.notion.com/"`            |
+| `files`            | `Array<{ name: string; url: string }>` | `[{ name: "brief.pdf", url: "https://..." }]` |
+| `people`           | `string[]`                             | `["1f4e6f4a-5b58-4d91-a7fc-2f5f2a0f6bb1"]`    |
+| `relation`         | `string[]`                             | `["6f7f9cbf-8d45-48f8-a194-661e73f7f5d9"]`    |
+| `created_by`       | `string`                               | `"Ada Lovelace"`                              |
+| `last_edited_by`   | `string`                               | `"user_123"`                                  |
+| `created_time`     | `string`                               | `"2026-03-01T10:30:00.000Z"`                  |
+| `last_edited_time` | `string`                               | `"2026-03-01T13:15:00.000Z"`                  |
+| `unique_id`        | `string`                               | `"TASK-42"`                                   |
 
 
 ## Unsupported properties

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ bun add @haustle/notion-orm
 
 After upgrading the package, run **`bun notion sync`** so generated files under **`notion/`** stay in sync with the version you installed (stale codegen can break at runtime when imports from the ORM package change). In app code, prefer **`import { NotionORM } from "./notion/"`** — the directory import resolves to `index.ts`, so you do not need to spell **`index`**.
 
-If you import agent factories directly from **`@haustle/notion-orm/notion/agents/<file>`** (instead of using `notion.agents.*` on `NotionORM`), the exported factory name is **PascalCase** (for example `MealAgent`), matching generated database modules. Update named imports after upgrading if you used a previous camelCase export.
+Generated database and agent modules live in your app's local **`./notion/`** folder after `notion sync`; import those relative files directly if you need a generated factory outside the `NotionORM` wrapper.
 
 # Quick start
 
@@ -381,10 +381,10 @@ See [API Reference](#api-reference) for full method signatures, `ThreadInfo` sha
 | import path                                    | what you get                                                                                                                                                                 | when to use                                                  |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | `./notion/` (relative)                         | `NotionORM` class (generated entry; same as `./notion/index` but shorter)                                                                                                    | Typical app code after **`notion sync`**                     |
-| `@haustle/notion-orm/notion/databases/<databaseName>`  | `<databaseName>(auth)` factory, `PageSchema`, `CreateSchema`, `QuerySchema`, generated Zod schema, generated option tuples (for select/status/multi-select), schema/type aliases | Script-level direct DB usage without the `NotionORM` wrapper |
-| `@haustle/notion-orm/notion/agents/<AgentName>` | `<AgentName>(auth)` factory that returns an `AgentClient` (PascalCase export; registry keys on `notion.agents` stay camelCase)                                                | Script-level direct agent usage                              |
-| `@haustle/notion-orm/notion/databases`                 | `databases` barrel object (all database factories)                                                                                                                           | Dynamic database selection or custom registry wiring         |
-| `@haustle/notion-orm/notion/agents`             | `agents` barrel object (all agent factories)                                                                                                                                 | Dynamic agent selection or custom registry wiring            |
+| `./notion/databases/<DatabaseName>.js`  | `<DatabaseName>(auth)` factory, `PageSchema`, `CreateSchema`, `QuerySchema`, generated Zod schema, generated option tuples (for select/status/multi-select), schema/type aliases | Script-level direct DB usage without the `NotionORM` wrapper |
+| `./notion/agents/<AgentName>.js` | `<AgentName>(auth)` factory that returns an `AgentClient` (PascalCase export; registry keys on `notion.agents` stay camelCase)                                                | Script-level direct agent usage                              |
+| `./notion/databases/index.js`                 | `databases` barrel object (all database factories)                                                                                                                           | Dynamic database selection or custom registry wiring         |
+| `./notion/agents/index.js`             | `agents` barrel object (all agent factories)                                                                                                                                 | Dynamic agent selection or custom registry wiring            |
 
 ## Thread response shapes
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@babel/generator": "^7.28.0",
         "@babel/parser": "^7.28.0",
         "@notionhq/client": "^5.14.0",
+        "dotenv": "^17.4.2",
         "zod": "^3.23.8",
       },
       "devDependencies": {
@@ -186,6 +187,8 @@
     "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
 
     "diff": ["diff@4.0.2", "", {}, "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="],
+
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 

--- a/docs/orm-architecture.md
+++ b/docs/orm-architecture.md
@@ -1,0 +1,324 @@
+# ORM Architecture Map
+
+This document explains how `@haustle/notion-orm` is structured today, how data flows through it, and which boundaries matter when refactoring.
+
+## What the package is
+
+`@haustle/notion-orm` is a hybrid package with two jobs:
+
+1. Ship the reusable runtime and CLI:
+  - `DatabaseClient`
+  - `AgentClient`
+  - shared schema/types/helpers
+  - the `notion` CLI
+2. Generate project-local code into a consumer's `./notion/` directory:
+  - typed database modules
+  - typed agent modules
+  - a generated `NotionORM` class that wires those modules together
+
+The key mental model is:
+
+```txt
+published package runtime + CLI
+            +
+consumer-local generated notion/
+            =
+typed Notion app experience
+```
+
+## Top-level package surfaces
+
+### `@haustle/notion-orm`
+
+The root package entry is the main consumer-facing surface for shared runtime values and types.
+
+Important exports:
+
+- `DatabaseClient`
+- `AgentClient`
+- `NotionORMBase`
+- default export `NotionORM` (stub class with empty registries)
+- branded Notion id helpers
+- schema and query types
+- `objectKeys` / `objectEntries`
+
+`src/index.ts` also exports a stub `NotionORM` class with empty `databases` and `agents` maps. That class is not the fully wired app ORM. The real app-facing `NotionORM` is generated into a consumer's local `./notion/index.ts`.
+
+### `@haustle/notion-orm/base`
+
+This is the lower-level contract used by generated code. The generated `./notion/index.ts` extends `NotionORMBase` from here.
+
+Use this entrypoint when working on the generated runtime contract itself.
+
+### `notion` CLI
+
+The CLI drives code generation and config bootstrapping:
+
+- `notion init`
+- `notion add`
+- `notion sync`
+- `notion setup-agents-sdk`
+
+## Directory map
+
+```txt
+src/
+  ast/                    codegen pipeline and emitters
+  cli/                    command routing and CLI-only helpers
+  client/
+    agent/                AgentClient runtime
+    database/             DatabaseClient runtime, query/create pipelines
+  config/                 config discovery, validation, auth loading
+  runtime-constants.ts    runtime strings/constants shared across layers
+  typeUtils.ts            typed object key/entry helpers
+  base.ts                 stable base surface for generated code
+  index.ts                root package surface
+
+tests/
+  runtime/                DatabaseClient, query, response, config runtime tests
+  codegen/                emitter and generation tests
+  cli/                    command routing and helper tests
+  types/                  compile-time API contract tests
+
+website/
+  package docs and playground site
+```
+
+## Layering model
+
+The simplest accurate dependency story is:
+
+```txt
+config/types + config/findConfigFile + runtime-constants
+                  |
+                  v
+        runtime clients and config loader
+                  |
+                  v
+              CLI orchestration
+                  |
+                  v
+          ast/ code generation pipeline
+                  |
+                  v
+       consumer-local generated ./notion/
+```
+
+More concretely:
+
+- `src/runtime-constants.ts` is the neutral home for runtime strings and version constants.
+- `src/config/types.ts` and `src/config/findConfigFile.ts` are shared config primitives.
+- `src/client/**` is the runtime package behavior.
+- `src/cli/**` is process/terminal orchestration.
+- `src/ast/**` is code generation.
+
+Runtime code should not need to look like it depends on AST internals just to get shared strings.
+
+## End-to-end database flow
+
+### 1. Codegen builds database metadata
+
+`notion sync` eventually calls `createDatabaseTypes()` in `src/ast/database/generate-databases-cli.ts`.
+
+That flow:
+
+1. Loads config from `src/config/loadConfig.ts`
+2. Calls the Notion API for each configured data source
+3. Converts Notion property metadata into generated TypeScript modules
+4. Writes:
+  - `notion/databases/<DatabaseName>.ts|js`
+  - `notion/databases/index.ts|js`
+  - `notion/databases/metadata.json`
+
+### 2. Generated modules construct `DatabaseClient`
+
+Each generated database module creates:
+
+- a narrow `columns` object
+- inferred schema/query/create types
+- a factory that returns `new DatabaseClient(...)`
+
+That `columns` object is the canonical bridge between generated static knowledge and runtime behavior.
+
+### 3. `DatabaseClient` runs typed operations
+
+`src/client/database/DatabaseClient.ts` is the main runtime coordinator.
+
+Important flows:
+
+- `create` / `update`:
+  - map local schema values to Notion property payloads
+  - call `pages.create` or `pages.update`
+- `findMany` / `findFirst` / `findUnique`:
+  - build Notion query params
+  - fetch results from Notion
+  - normalize page properties into simpler ORM row shapes
+  - validate schema drift
+  - apply `select` / `omit` projection
+- `delete`:
+  - soft delete via `in_trash: true`
+
+## Query pipeline map
+
+The query pipeline under `src/client/database/query/` has four main responsibilities:
+
+1. `build-query-params.ts`
+  - converts ORM query args into Notion API params
+2. `filter/`
+  - transforms typed filter input into Notion filter payloads
+3. `normalize-page-result.ts` and `response/`
+  - converts raw Notion property values into simpler row values
+4. `projection.ts`
+  - applies `select` / `omit`
+
+Schema drift validation lives in `schema-drift-validation.ts`. It warns when generated local expectations and live Notion responses diverge.
+
+## Create/update pipeline map
+
+The create path under `src/client/database/create/` turns ORM input values into Notion property payloads.
+
+Core modules:
+
+- `map-to-notion-properties.ts`
+- `property-value.ts`
+- `build-create-page-parameters.ts`
+
+This is the write-side mirror of the query/response pipeline.
+
+## Agent flow
+
+Agent support is parallel to database support:
+
+- codegen lives in `src/ast/agents/`
+- runtime client lives in `src/client/agent/AgentClient.ts`
+- setup/install support lives in `src/agents-sdk-resolver.ts` and `src/cli/agents-sdk-setup.ts`
+
+Agent codegen emits:
+
+- `notion/agents/<AgentName>.ts|js`
+- `notion/agents/index.ts|js`
+- `notion/agents/metadata.json`
+
+## Config flow
+
+Config has three distinct concerns:
+
+1. `src/config/findConfigFile.ts`
+  - find `notion.config.*`
+2. `src/config/loadConfig.ts`
+  - load and validate config with Zod
+  - cache the resolved config per process
+3. `src/config/helpers.ts`
+  - CLI-facing validation and `notion init`
+
+This separation matters because discovery and shape validation are core boundaries, while CLI printing/exiting is not.
+
+## Codegen flow
+
+The full `notion sync` flow is:
+
+1. validate config
+2. remove existing generated `./notion/`
+3. generate databases and agents in parallel
+4. re-read metadata from disk
+5. emit the root `notion/index.ts|js` and `index.d.ts`
+
+The root generated index is emitted by `src/ast/shared/emit/orm-index-emitter.ts`.
+
+That file builds the generated `NotionORM` class that:
+
+- extends `NotionORMBase`
+- resolves auth once
+- assigns `this.databases`
+- assigns `this.agents`
+
+## Type system map
+
+The strongest type source-of-truth is the generated `columns` metadata.
+
+Important type hubs:
+
+- `src/client/database/types/schema.ts`
+- `src/client/database/types/query-filter.ts`
+- `src/client/database/types/projection.ts`
+- `src/client/database/types/crud.ts`
+
+Project typing rules from `AGENTS.md` show up in a few key patterns:
+
+- derive unions from canonical maps
+- prefer `satisfies Record<...>`
+- use `objectKeys` / `objectEntries` for typed iteration
+- validate untrusted boundaries with Zod
+
+## Test map
+
+The tests already separate the package into useful seams:
+
+- `tests/runtime/`
+  - runtime database behavior
+  - query normalization
+  - config loading
+- `tests/codegen/`
+  - emitter behavior
+  - generated output structure
+- `tests/cli/`
+  - command routing
+  - helper behavior
+- `tests/types/`
+  - compile-time contract tests
+
+This is useful when making structural changes: prefer refactors that preserve these seams instead of smearing concerns together.
+
+## Structural cleanup done in this pass
+
+This refactor intentionally stayed non-breaking and boundary-focused.
+
+### 1. Runtime constants moved out of `src/ast/`
+
+`src/runtime-constants.ts` now owns runtime-only constants. `src/ast/shared/constants.ts` keeps a compatibility alias for codegen callers, but runtime modules can import from a neutral path.
+
+This makes the layering more honest:
+
+- runtime code no longer looks like it depends on AST internals just for strings and version constants
+- future splits between runtime and codegen are easier
+
+### 2. Config discovery and config types were split out
+
+Added:
+
+- `src/config/types.ts`
+- `src/config/findConfigFile.ts`
+
+This breaks the old `config/helpers` <-> `config/loadConfig` cycle and makes shared config primitives easier to reason about.
+
+### 3. CLI sync progress renderer was extracted
+
+`SyncProgressRenderer` now lives in `src/cli/sync-progress-renderer.ts`, which makes `src/cli/index.ts` more obviously about command flow instead of terminal rendering internals.
+
+### 4. Query response typing was tightened
+
+`build-query-response.ts`, `normalize-page-result.ts`, and the resolver registry now constrain normalized row values with `DatabasePropertyValue` instead of `unknown`, which better matches the rest of the runtime type model.
+
+The malformed-fixture test helpers still intentionally use `unknown` at a few edges when asserting bad payloads. That looseness is confined to test scaffolding for invalid cases, not the production query pipeline contract.
+
+## Good next structural moves
+
+These are the next high-value changes if you want to keep making the package more canonical without breaking the public surface.
+
+1. Split `orm-index-emitter.ts` into smaller runtime/declaration pieces
+2. Split config-file AST editing out of `src/cli/helpers.ts`
+3. Add direct tests for `AgentClient` and agent codegen
+4. Consider one small shared helper for repeated "normalize page results and validate first row" loops
+5. Revisit the package export surface so `./base` is the only canonical low-level subpath
+
+## Refactor heuristics for this repo
+
+When simplifying this package, the best wins tend to be:
+
+- move shared primitives to neutral modules
+- split orchestration from pure transforms
+- keep exhaustive typed registries
+- derive types from generated `columns`
+- avoid stringly duplicate sources of truth
+
+The worst trade is "less code" that weakens the schema/type contract. In this repo, dumb and simple should still be strongly typed.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"site": "bun run --cwd website  dev",
 		"site:deploy": "bun run --cwd website  deploy",
 		"site:typecheck": "bun run --cwd website  typecheck",
-		"unpack-size": "bun pm pack --dry-run 2>&1 | rg 'unpacked size'",
+		"unpack-size": "bun pm pack --dry-run",
 		"loop": "bun run build:link && cd ../orm-testing && bun link @haustle/notion-orm && bunx notion sync && bun run smoke/coffee-shop/run.ts",
 		"refresh": "rm -rf ./node_modules && bun install"
 	},

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
 		"bun-types": "^1.3.11",
 		"husky": "^9.1.7",
 		"knip": "^6.4.1",
-		"tsx": "^4.21.0",
 		"typescript": "^5.6.3"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
 	},
 	"scripts": {
 		"prepare": "husky",
-		"start": "bun run build && bun build/src/index.js",
-		"build": "rm -rf build && tsc && node ./scripts/patch-build-import-extensions.mjs",
-		"build:link": "npm run build && bun link",
+		"start": "bun run build && node build/src/index.js",
+		"build": "rm -rf build && tsc && node ./scripts/patch-build-import-extensions.mjs && chmod +x build/src/cli/index.js",
+		"build:link": "bun run build && bun link",
 		"test": "bun test",
 		"test:types": "tsc -p tests/types/tsconfig.json --noEmit",
 		"lint": "biome lint tests/runtime tests/cli tests/codegen tests/helpers tests/types --diagnostic-level=error",
@@ -43,9 +43,9 @@
 		"site": "bun run --cwd website  dev",
 		"site:deploy": "bun run --cwd website  deploy",
 		"site:typecheck": "bun run --cwd website  typecheck",
-		"unpack-size": "npm pack --dry-run 2>&1 | grep 'unpacked size'",
-		"loop": "bun run build:link && cd ../orm-testing && bun link @haustle/notion-orm && bun notion sync && bun run smoke/coffee-shop/run.ts",
-		"refresh": "rm -rf ./node_modules ./bun.lockb && bun install"
+		"unpack-size": "bun pm pack --dry-run 2>&1 | rg 'unpacked size'",
+		"loop": "bun run build:link && cd ../orm-testing && bun link @haustle/notion-orm && bunx notion sync && bun run smoke/coffee-shop/run.ts",
+		"refresh": "rm -rf ./node_modules && bun install"
 	},
 	"author": "",
 	"license": "ISC",
@@ -62,6 +62,7 @@
 		"@babel/generator": "^7.28.0",
 		"@babel/parser": "^7.28.0",
 		"@notionhq/client": "^5.14.0",
+		"dotenv": "^17.4.2",
 		"zod": "^3.23.8"
 	},
 	"optionalDependencies": {
@@ -70,6 +71,9 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Haustle/notion-orm"
+	},
+	"engines": {
+		"node": ">=18"
 	},
 	"homepage": "https://github.com/Haustle/notion-orm#readme",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -4,6 +4,26 @@
 	"type": "module",
 	"description": "tool to bring notion databases schemas/types to typescript",
 	"main": "build/src/index.js",
+	"types": "build/src/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./build/src/index.d.ts",
+			"default": "./build/src/index.js"
+		},
+		"./base": {
+			"types": "./build/src/base.d.ts",
+			"default": "./build/src/base.js"
+		},
+		"./build/src/base": {
+			"types": "./build/src/base.d.ts",
+			"default": "./build/src/base.js"
+		},
+		"./notion-id-patterns": {
+			"types": "./build/src/notion-id-patterns.d.ts",
+			"default": "./build/src/notion-id-patterns.js"
+		},
+		"./package.json": "./package.json"
+	},
 	"files": [
 		"/build"
 	],
@@ -13,7 +33,8 @@
 	"scripts": {
 		"prepare": "husky",
 		"start": "bun run build && bun build/src/index.js",
-		"build": "rm -rf build && bunx tsc && bun link",
+		"build": "rm -rf build && bunx tsc",
+		"build:link": "bun run build && bun link",
 		"test": "bun test",
 		"test:types": "bunx tsc -p tests/types/tsconfig.json --noEmit",
 		"lint": "bunx biome lint tests/runtime tests/cli tests/codegen tests/helpers tests/types --diagnostic-level=error",
@@ -23,7 +44,7 @@
 		"site:deploy": "bun run --cwd website  deploy",
 		"site:typecheck": "bun run --cwd website  typecheck",
 		"unpack-size": "npm pack --dry-run 2>&1 | grep 'unpacked size'",
-		"loop": "bun run build && cd ../orm-testing && bun link @haustle/notion-orm && bun notion sync && bun run smoke/coffee-shop/run.ts",
+		"loop": "bun run build:link && cd ../orm-testing && bun link @haustle/notion-orm && bun notion sync && bun run smoke/coffee-shop/run.ts",
 		"refresh": "rm -rf ./node_modules ./bun.lockb && bun install"
 	},
 	"author": "",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
 	"scripts": {
 		"prepare": "husky",
 		"start": "bun run build && bun build/src/index.js",
-		"build": "rm -rf build && bunx tsc",
-		"build:link": "bun run build && bun link",
+		"build": "rm -rf build && tsc",
+		"build:link": "npm run build && bun link",
 		"test": "bun test",
-		"test:types": "bunx tsc -p tests/types/tsconfig.json --noEmit",
-		"lint": "bunx biome lint tests/runtime tests/cli tests/codegen tests/helpers tests/types --diagnostic-level=error",
-		"typecheck": "bunx tsc --noEmit && bunx tsc -p tests/tsconfig.json --noEmit",
+		"test:types": "tsc -p tests/types/tsconfig.json --noEmit",
+		"lint": "biome lint tests/runtime tests/cli tests/codegen tests/helpers tests/types --diagnostic-level=error",
+		"typecheck": "tsc --noEmit && tsc -p tests/tsconfig.json --noEmit",
 		"knip": "knip",
 		"site": "bun run --cwd website  dev",
 		"site:deploy": "bun run --cwd website  deploy",
@@ -56,6 +56,7 @@
 		"bun-types": "^1.3.11",
 		"husky": "^9.1.7",
 		"knip": "^6.4.1",
+		"tsx": "^4.21.0",
 		"typescript": "^5.6.3"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"scripts": {
 		"prepare": "husky",
 		"start": "bun run build && bun build/src/index.js",
-		"build": "rm -rf build && tsc",
+		"build": "rm -rf build && tsc && node ./scripts/patch-build-import-extensions.mjs",
 		"build:link": "npm run build && bun link",
 		"test": "bun test",
 		"test:types": "tsc -p tests/types/tsconfig.json --noEmit",

--- a/scripts/patch-build-import-extensions.mjs
+++ b/scripts/patch-build-import-extensions.mjs
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const BUILD_ROOT = path.resolve(process.cwd(), "build");
+const JS_EXTENSIONS = new Set([".js", ".mjs", ".cjs", ".json"]);
+
+function shouldRewriteSpecifier(specifier) {
+	return (
+		(specifier.startsWith("./") || specifier.startsWith("../")) &&
+		!path.extname(specifier) &&
+		!specifier.endsWith("/")
+	);
+}
+
+function rewriteRelativeImportSpecifiers(source) {
+	return source.replace(
+		/(from\s+["'])(\.{1,2}\/[^"'?#]+)(["'])|((?:import|export)\s*\(\s*["'])(\.{1,2}\/[^"'?#]+)(["']\s*\))/g,
+		(...args) => {
+			const staticPrefix = args[1];
+			const staticSpecifier = args[2];
+			const staticSuffix = args[3];
+			if (staticSpecifier && staticPrefix && staticSuffix) {
+				return shouldRewriteSpecifier(staticSpecifier)
+					? `${staticPrefix}${staticSpecifier}.js${staticSuffix}`
+					: `${staticPrefix}${staticSpecifier}${staticSuffix}`;
+			}
+
+			const dynamicPrefix = args[4];
+			const dynamicSpecifier = args[5];
+			const dynamicSuffix = args[6];
+			if (dynamicSpecifier && dynamicPrefix && dynamicSuffix) {
+				return shouldRewriteSpecifier(dynamicSpecifier)
+					? `${dynamicPrefix}${dynamicSpecifier}.js${dynamicSuffix}`
+					: `${dynamicPrefix}${dynamicSpecifier}${dynamicSuffix}`;
+			}
+
+			return args[0];
+		},
+	);
+}
+
+function patchBuildDirectory(directory) {
+	for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+		const fullPath = path.join(directory, entry.name);
+		if (entry.isDirectory()) {
+			patchBuildDirectory(fullPath);
+			continue;
+		}
+
+		if (!JS_EXTENSIONS.has(path.extname(entry.name))) {
+			continue;
+		}
+		if (path.extname(entry.name) !== ".js") {
+			continue;
+		}
+
+		const original = fs.readFileSync(fullPath, "utf8");
+		const updated = rewriteRelativeImportSpecifiers(original);
+		if (updated !== original) {
+			fs.writeFileSync(fullPath, updated);
+		}
+	}
+}
+
+if (fs.existsSync(BUILD_ROOT)) {
+	patchBuildDirectory(BUILD_ROOT);
+}

--- a/scripts/patch-build-import-extensions.mjs
+++ b/scripts/patch-build-import-extensions.mjs
@@ -1,42 +1,146 @@
 import fs from "node:fs";
 import path from "node:path";
+import * as parser from "@babel/parser";
+import * as t from "@babel/types";
 
 const BUILD_ROOT = path.resolve(process.cwd(), "build");
-const JS_EXTENSIONS = new Set([".js", ".mjs", ".cjs", ".json"]);
+const PATCHABLE_EXTENSION = ".js";
+
+function splitSpecifierSuffix(specifier) {
+	const suffixStart = specifier.search(/[?#]/);
+	if (suffixStart === -1) {
+		return {
+			pathname: specifier,
+			suffix: "",
+		};
+	}
+	return {
+		pathname: specifier.slice(0, suffixStart),
+		suffix: specifier.slice(suffixStart),
+	};
+}
 
 function shouldRewriteSpecifier(specifier) {
+	const { pathname } = splitSpecifierSuffix(specifier);
 	return (
-		(specifier.startsWith("./") || specifier.startsWith("../")) &&
-		!path.extname(specifier) &&
-		!specifier.endsWith("/")
+		(pathname.startsWith("./") || pathname.startsWith("../")) &&
+		!path.extname(pathname) &&
+		!pathname.endsWith("/")
 	);
 }
 
-function rewriteRelativeImportSpecifiers(source) {
-	return source.replace(
-		/(from\s+["'])(\.{1,2}\/[^"'?#]+)(["'])|((?:import|export)\s*\(\s*["'])(\.{1,2}\/[^"'?#]+)(["']\s*\))/g,
-		(...args) => {
-			const staticPrefix = args[1];
-			const staticSpecifier = args[2];
-			const staticSuffix = args[3];
-			if (staticSpecifier && staticPrefix && staticSuffix) {
-				return shouldRewriteSpecifier(staticSpecifier)
-					? `${staticPrefix}${staticSpecifier}.js${staticSuffix}`
-					: `${staticPrefix}${staticSpecifier}${staticSuffix}`;
-			}
+function rewriteSpecifier(specifier) {
+	if (!shouldRewriteSpecifier(specifier)) {
+		return specifier;
+	}
+	const { pathname, suffix } = splitSpecifierSuffix(specifier);
+	return `${pathname}.js${suffix}`;
+}
 
-			const dynamicPrefix = args[4];
-			const dynamicSpecifier = args[5];
-			const dynamicSuffix = args[6];
-			if (dynamicSpecifier && dynamicPrefix && dynamicSuffix) {
-				return shouldRewriteSpecifier(dynamicSpecifier)
-					? `${dynamicPrefix}${dynamicSpecifier}.js${dynamicSuffix}`
-					: `${dynamicPrefix}${dynamicSpecifier}${dynamicSuffix}`;
-			}
+function parseModuleSource(source) {
+	return parser.parse(source, {
+		sourceType: "unambiguous",
+		plugins: ["importAttributes"],
+	});
+}
 
-			return args[0];
-		},
-	);
+function walkAst(node, visitor) {
+	if (!node || typeof node !== "object") {
+		return;
+	}
+	visitor(node);
+	const childKeys = t.VISITOR_KEYS[node.type] ?? [];
+	for (const childKey of childKeys) {
+		const child = node[childKey];
+		if (Array.isArray(child)) {
+			for (const nestedChild of child) {
+				walkAst(nestedChild, visitor);
+			}
+			continue;
+		}
+		walkAst(child, visitor);
+	}
+}
+
+function buildSpecifierEdit(args) {
+	const { literal, source } = args;
+	if (literal.start == null || literal.end == null) {
+		return undefined;
+	}
+	const rewrittenSpecifier = rewriteSpecifier(literal.value);
+	if (rewrittenSpecifier === literal.value) {
+		return undefined;
+	}
+	const rawLiteral = source.slice(literal.start, literal.end);
+	const quote = rawLiteral[0];
+	const preservesOriginalQuotes =
+		(quote === '"' || quote === "'") && rawLiteral.at(-1) === quote;
+	return {
+		start: literal.start,
+		end: literal.end,
+		replacement: preservesOriginalQuotes
+			? `${quote}${rewrittenSpecifier}${quote}`
+			: JSON.stringify(rewrittenSpecifier),
+	};
+}
+
+function collectSpecifierEdits(source) {
+	const ast = parseModuleSource(source);
+	const edits = [];
+	walkAst(ast.program, (node) => {
+		if (
+			(t.isImportDeclaration(node) ||
+				t.isExportNamedDeclaration(node) ||
+				t.isExportAllDeclaration(node)) &&
+			node.source &&
+			t.isStringLiteral(node.source)
+		) {
+			const edit = buildSpecifierEdit({
+				literal: node.source,
+				source,
+			});
+			if (edit) {
+				edits.push(edit);
+			}
+			return;
+		}
+		if (t.isImportExpression(node) && t.isStringLiteral(node.source)) {
+			const edit = buildSpecifierEdit({
+				literal: node.source,
+				source,
+			});
+			if (edit) {
+				edits.push(edit);
+			}
+			return;
+		}
+		if (
+			t.isCallExpression(node) &&
+			t.isImport(node.callee) &&
+			node.arguments.length > 0 &&
+			t.isStringLiteral(node.arguments[0])
+		) {
+			const edit = buildSpecifierEdit({
+				literal: node.arguments[0],
+				source,
+			});
+			if (edit) {
+				edits.push(edit);
+			}
+		}
+	});
+	return edits.sort((left, right) => right.start - left.start);
+}
+
+export function rewriteRelativeImportSpecifiers(source) {
+	let updated = source;
+	for (const edit of collectSpecifierEdits(source)) {
+		updated =
+			updated.slice(0, edit.start) +
+			edit.replacement +
+			updated.slice(edit.end);
+	}
+	return updated;
 }
 
 function patchBuildDirectory(directory) {
@@ -47,10 +151,7 @@ function patchBuildDirectory(directory) {
 			continue;
 		}
 
-		if (!JS_EXTENSIONS.has(path.extname(entry.name))) {
-			continue;
-		}
-		if (path.extname(entry.name) !== ".js") {
+		if (path.extname(entry.name) !== PATCHABLE_EXTENSION) {
 			continue;
 		}
 

--- a/scripts/patch-build-import-extensions.mjs
+++ b/scripts/patch-build-import-extensions.mjs
@@ -1,27 +1,32 @@
 import fs from "node:fs";
 import path from "node:path";
-import * as parser from "@babel/parser";
-import * as t from "@babel/types";
+import * as babelParser from "@babel/parser";
+import * as babelTypes from "@babel/types";
 
+/**
+ * Rewrites extensionless relative specifiers in emitted JS files to explicit
+ * `.js` or `/index.js` forms so Node ESM resolution is deterministic.
+ */
 const BUILD_ROOT = path.resolve(process.cwd(), "build");
-const PATCHABLE_EXTENSION = ".js";
+const JAVASCRIPT_EXTENSION = ".js";
+const INDEX_BASENAME = "index.js";
 
-function splitSpecifierSuffix(specifier) {
-	const suffixStart = specifier.search(/[?#]/);
+function splitImportPathAndSuffix(importPathText) {
+	const suffixStart = importPathText.search(/[?#]/);
 	if (suffixStart === -1) {
 		return {
-			pathname: specifier,
+			pathname: importPathText,
 			suffix: "",
 		};
 	}
 	return {
-		pathname: specifier.slice(0, suffixStart),
-		suffix: specifier.slice(suffixStart),
+		pathname: importPathText.slice(0, suffixStart),
+		suffix: importPathText.slice(suffixStart),
 	};
 }
 
-function shouldRewriteSpecifier(specifier) {
-	const { pathname } = splitSpecifierSuffix(specifier);
+function isRelativeImportPathWithoutExtension(importPathText) {
+	const { pathname } = splitImportPathAndSuffix(importPathText);
 	return (
 		(pathname.startsWith("./") || pathname.startsWith("../")) &&
 		!path.extname(pathname) &&
@@ -30,151 +35,178 @@ function shouldRewriteSpecifier(specifier) {
 }
 
 /**
- * TypeScript may emit `from "../dir"` when `../dir/index.ts` is the target.
- * Node ESM needs `../dir/index.js`, not `../dir.js`.
+ * TypeScript may emit an import path like `"../dir"` for a real
+ * `../dir/index.js` target.
+ * Node ESM requires fully specified directory indexes (`../dir/index.js`).
  */
-function rewriteSpecifier(specifier, importerPath) {
-	if (!shouldRewriteSpecifier(specifier)) {
-		return specifier;
+function rewriteRelativeImportPath(importPathText, importerFilePath) {
+	if (!isRelativeImportPathWithoutExtension(importPathText)) {
+		return importPathText;
 	}
-	const { pathname, suffix } = splitSpecifierSuffix(specifier);
-	if (!importerPath) {
-		return `${pathname}.js${suffix}`;
+	const { pathname, suffix } = splitImportPathAndSuffix(importPathText);
+	if (!importerFilePath) {
+		return `${pathname}${JAVASCRIPT_EXTENSION}${suffix}`;
 	}
-	const baseDir = path.dirname(importerPath);
-	const resolvedDir = path.resolve(baseDir, pathname);
-	const asFile = `${resolvedDir}.js`;
-	const asIndex = path.join(resolvedDir, "index.js");
-	let target = `${pathname}.js`;
-	if (!fs.existsSync(asFile) && fs.existsSync(asIndex)) {
-		target = `${pathname}/index.js`;
+
+	const importerDirectoryPath = path.dirname(importerFilePath);
+	const resolvedImportPath = path.resolve(importerDirectoryPath, pathname);
+	const resolvedFilePath = `${resolvedImportPath}${JAVASCRIPT_EXTENSION}`;
+	const resolvedIndexPath = path.join(resolvedImportPath, INDEX_BASENAME);
+
+	let rewrittenPathname = `${pathname}${JAVASCRIPT_EXTENSION}`;
+	if (!fs.existsSync(resolvedFilePath) && fs.existsSync(resolvedIndexPath)) {
+		rewrittenPathname = `${pathname}/${INDEX_BASENAME}`;
 	}
-	return `${target}${suffix}`;
+	return `${rewrittenPathname}${suffix}`;
 }
 
-function parseModuleSource(source) {
-	return parser.parse(source, {
+function parseModuleSource(moduleSourceText) {
+	return babelParser.parse(moduleSourceText, {
 		sourceType: "unambiguous",
 		plugins: ["importAttributes"],
 	});
 }
 
-function walkAst(node, visitor) {
-	if (!node || typeof node !== "object") {
+function visitAst(astNode, visitor) {
+	if (!astNode || typeof astNode !== "object") {
 		return;
 	}
-	visitor(node);
-	const childKeys = t.VISITOR_KEYS[node.type] ?? [];
-	for (const childKey of childKeys) {
-		const child = node[childKey];
-		if (Array.isArray(child)) {
-			for (const nestedChild of child) {
-				walkAst(nestedChild, visitor);
+	visitor(astNode);
+	const childPropertyNames = babelTypes.VISITOR_KEYS[astNode.type] ?? [];
+	for (const childPropertyName of childPropertyNames) {
+		const childNode = astNode[childPropertyName];
+		if (Array.isArray(childNode)) {
+			for (const nestedChildNode of childNode) {
+				visitAst(nestedChildNode, visitor);
 			}
 			continue;
 		}
-		walkAst(child, visitor);
+		visitAst(childNode, visitor);
 	}
 }
 
-function buildSpecifierEdit(args) {
-	const { literal, source, importerPath } = args;
-	if (literal.start == null || literal.end == null) {
+function createImportPathEdit(args) {
+	const { importPathLiteralNode, moduleSourceText, importerFilePath } = args;
+	if (importPathLiteralNode.start == null || importPathLiteralNode.end == null) {
 		return undefined;
 	}
-	const rewrittenSpecifier = rewriteSpecifier(literal.value, importerPath);
-	if (rewrittenSpecifier === literal.value) {
+	const rewrittenImportPathText = rewriteRelativeImportPath(
+		importPathLiteralNode.value,
+		importerFilePath,
+	);
+	if (rewrittenImportPathText === importPathLiteralNode.value) {
 		return undefined;
 	}
-	const rawLiteral = source.slice(literal.start, literal.end);
-	const quote = rawLiteral[0];
+	const originalLiteralSource = moduleSourceText.slice(
+		importPathLiteralNode.start,
+		importPathLiteralNode.end,
+	);
+	const quoteCharacter = originalLiteralSource[0];
 	const preservesOriginalQuotes =
-		(quote === '"' || quote === "'") && rawLiteral.at(-1) === quote;
+		(quoteCharacter === '"' || quoteCharacter === "'") &&
+		originalLiteralSource.at(-1) === quoteCharacter;
 	return {
-		start: literal.start,
-		end: literal.end,
+		start: importPathLiteralNode.start,
+		end: importPathLiteralNode.end,
 		replacement: preservesOriginalQuotes
-			? `${quote}${rewrittenSpecifier}${quote}`
-			: JSON.stringify(rewrittenSpecifier),
+			? `${quoteCharacter}${rewrittenImportPathText}${quoteCharacter}`
+			: JSON.stringify(rewrittenImportPathText),
 	};
 }
 
-function collectSpecifierEdits(source, importerPath) {
-	const ast = parseModuleSource(source);
-	const edits = [];
-	walkAst(ast.program, (node) => {
-		if (
-			(t.isImportDeclaration(node) ||
-				t.isExportNamedDeclaration(node) ||
-				t.isExportAllDeclaration(node)) &&
-			node.source &&
-			t.isStringLiteral(node.source)
-		) {
-			const edit = buildSpecifierEdit({
-				literal: node.source,
-				source,
-				importerPath,
-			});
-			if (edit) {
-				edits.push(edit);
-			}
+function getImportPathLiteralNode(astNode) {
+	const sourceLiteralNode =
+		babelTypes.isImportDeclaration(astNode) ||
+		babelTypes.isExportNamedDeclaration(astNode) ||
+		babelTypes.isExportAllDeclaration(astNode) ||
+		babelTypes.isImportExpression(astNode)
+			? astNode.source
+			: undefined;
+	if (sourceLiteralNode && babelTypes.isStringLiteral(sourceLiteralNode)) {
+		return sourceLiteralNode;
+	}
+	if (
+		babelTypes.isCallExpression(astNode) &&
+		babelTypes.isImport(astNode.callee) &&
+		astNode.arguments.length > 0 &&
+		babelTypes.isStringLiteral(astNode.arguments[0])
+	) {
+		return astNode.arguments[0];
+	}
+	return undefined;
+}
+
+function collectImportPathEdits(moduleSourceText, importerFilePath) {
+	let parsedModuleAst;
+	try {
+		parsedModuleAst = parseModuleSource(moduleSourceText);
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		const fileLabel = importerFilePath ?? "<unknown>";
+		console.warn(
+			`Warning: skipping import-path rewrite for ${fileLabel}: ${reason}`,
+		);
+		return [];
+	}
+
+	const importPathEdits = [];
+	visitAst(parsedModuleAst.program, (astNode) => {
+		const importPathLiteralNode = getImportPathLiteralNode(astNode);
+		if (!importPathLiteralNode) {
 			return;
 		}
-		if (t.isImportExpression(node) && t.isStringLiteral(node.source)) {
-			const edit = buildSpecifierEdit({
-				literal: node.source,
-				source,
-				importerPath,
-			});
-			if (edit) {
-				edits.push(edit);
-			}
-			return;
-		}
-		if (
-			t.isCallExpression(node) &&
-			t.isImport(node.callee) &&
-			node.arguments.length > 0 &&
-			t.isStringLiteral(node.arguments[0])
-		) {
-			const edit = buildSpecifierEdit({
-				literal: node.arguments[0],
-				source,
-				importerPath,
-			});
-			if (edit) {
-				edits.push(edit);
-			}
+		const edit = createImportPathEdit({
+			importPathLiteralNode,
+			moduleSourceText,
+			importerFilePath,
+		});
+		if (edit) {
+			importPathEdits.push(edit);
 		}
 	});
-	return edits.sort((left, right) => right.start - left.start);
+	return importPathEdits.sort(
+		(laterEdit, earlierEdit) => earlierEdit.start - laterEdit.start,
+	);
 }
 
-export function rewriteRelativeImportSpecifiers(source, importerPath) {
-	let updated = source;
-	for (const edit of collectSpecifierEdits(source, importerPath)) {
-		updated =
-			updated.slice(0, edit.start) + edit.replacement + updated.slice(edit.end);
+export function rewriteRelativeImportSpecifiers(
+	moduleSourceText,
+	importerFilePath,
+) {
+	let rewrittenModuleSourceText = moduleSourceText;
+	for (const importPathEdit of collectImportPathEdits(
+		moduleSourceText,
+		importerFilePath,
+	)) {
+		rewrittenModuleSourceText =
+			rewrittenModuleSourceText.slice(0, importPathEdit.start) +
+			importPathEdit.replacement +
+			rewrittenModuleSourceText.slice(importPathEdit.end);
 	}
-	return updated;
+	return rewrittenModuleSourceText;
 }
 
-function patchBuildDirectory(directory) {
-	for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-		const fullPath = path.join(directory, entry.name);
-		if (entry.isDirectory()) {
-			patchBuildDirectory(fullPath);
+function patchBuildDirectory(directoryPath) {
+	for (const directoryEntry of fs.readdirSync(directoryPath, {
+		withFileTypes: true,
+	})) {
+		const entryPath = path.join(directoryPath, directoryEntry.name);
+		if (directoryEntry.isDirectory()) {
+			patchBuildDirectory(entryPath);
 			continue;
 		}
 
-		if (path.extname(entry.name) !== PATCHABLE_EXTENSION) {
+		if (path.extname(directoryEntry.name) !== JAVASCRIPT_EXTENSION) {
 			continue;
 		}
 
-		const original = fs.readFileSync(fullPath, "utf8");
-		const updated = rewriteRelativeImportSpecifiers(original, fullPath);
-		if (updated !== original) {
-			fs.writeFileSync(fullPath, updated);
+		const originalFileSource = fs.readFileSync(entryPath, "utf8");
+		const rewrittenFileSource = rewriteRelativeImportSpecifiers(
+			originalFileSource,
+			entryPath,
+		);
+		if (rewrittenFileSource !== originalFileSource) {
+			fs.writeFileSync(entryPath, rewrittenFileSource);
 		}
 	}
 }

--- a/scripts/patch-build-import-extensions.mjs
+++ b/scripts/patch-build-import-extensions.mjs
@@ -29,12 +29,27 @@ function shouldRewriteSpecifier(specifier) {
 	);
 }
 
-function rewriteSpecifier(specifier) {
+/**
+ * TypeScript may emit `from "../dir"` when `../dir/index.ts` is the target.
+ * Node ESM needs `../dir/index.js`, not `../dir.js`.
+ */
+function rewriteSpecifier(specifier, importerPath) {
 	if (!shouldRewriteSpecifier(specifier)) {
 		return specifier;
 	}
 	const { pathname, suffix } = splitSpecifierSuffix(specifier);
-	return `${pathname}.js${suffix}`;
+	if (!importerPath) {
+		return `${pathname}.js${suffix}`;
+	}
+	const baseDir = path.dirname(importerPath);
+	const resolvedDir = path.resolve(baseDir, pathname);
+	const asFile = `${resolvedDir}.js`;
+	const asIndex = path.join(resolvedDir, "index.js");
+	let target = `${pathname}.js`;
+	if (!fs.existsSync(asFile) && fs.existsSync(asIndex)) {
+		target = `${pathname}/index.js`;
+	}
+	return `${target}${suffix}`;
 }
 
 function parseModuleSource(source) {
@@ -63,11 +78,11 @@ function walkAst(node, visitor) {
 }
 
 function buildSpecifierEdit(args) {
-	const { literal, source } = args;
+	const { literal, source, importerPath } = args;
 	if (literal.start == null || literal.end == null) {
 		return undefined;
 	}
-	const rewrittenSpecifier = rewriteSpecifier(literal.value);
+	const rewrittenSpecifier = rewriteSpecifier(literal.value, importerPath);
 	if (rewrittenSpecifier === literal.value) {
 		return undefined;
 	}
@@ -84,7 +99,7 @@ function buildSpecifierEdit(args) {
 	};
 }
 
-function collectSpecifierEdits(source) {
+function collectSpecifierEdits(source, importerPath) {
 	const ast = parseModuleSource(source);
 	const edits = [];
 	walkAst(ast.program, (node) => {
@@ -98,6 +113,7 @@ function collectSpecifierEdits(source) {
 			const edit = buildSpecifierEdit({
 				literal: node.source,
 				source,
+				importerPath,
 			});
 			if (edit) {
 				edits.push(edit);
@@ -108,6 +124,7 @@ function collectSpecifierEdits(source) {
 			const edit = buildSpecifierEdit({
 				literal: node.source,
 				source,
+				importerPath,
 			});
 			if (edit) {
 				edits.push(edit);
@@ -123,6 +140,7 @@ function collectSpecifierEdits(source) {
 			const edit = buildSpecifierEdit({
 				literal: node.arguments[0],
 				source,
+				importerPath,
 			});
 			if (edit) {
 				edits.push(edit);
@@ -132,13 +150,11 @@ function collectSpecifierEdits(source) {
 	return edits.sort((left, right) => right.start - left.start);
 }
 
-export function rewriteRelativeImportSpecifiers(source) {
+export function rewriteRelativeImportSpecifiers(source, importerPath) {
 	let updated = source;
-	for (const edit of collectSpecifierEdits(source)) {
+	for (const edit of collectSpecifierEdits(source, importerPath)) {
 		updated =
-			updated.slice(0, edit.start) +
-			edit.replacement +
-			updated.slice(edit.end);
+			updated.slice(0, edit.start) + edit.replacement + updated.slice(edit.end);
 	}
 	return updated;
 }
@@ -156,7 +172,7 @@ function patchBuildDirectory(directory) {
 		}
 
 		const original = fs.readFileSync(fullPath, "utf8");
-		const updated = rewriteRelativeImportSpecifiers(original);
+		const updated = rewriteRelativeImportSpecifiers(original, fullPath);
 		if (updated !== original) {
 			fs.writeFileSync(fullPath, updated);
 		}

--- a/src/agents-sdk-resolver.ts
+++ b/src/agents-sdk-resolver.ts
@@ -12,7 +12,7 @@ const AGENTS_SDK_MISSING_MESSAGE =
 	`Agent support requires the Notion Agents SDK (paid feature).\n` +
 	`Run \`${AGENTS_SDK_SETUP_COMMAND}\` to install it, then run \`notion sync\`.`;
 
-/** Filesystem probe instead of `createRequire` for Bun + Node compatibility. */
+/** Filesystem probe instead of `createRequire` so resolution works the same in Node and other runtimes. */
 export function isAgentsSdkAvailable(): boolean {
 	const sdkPackageJson = path.join(
 		process.cwd(),

--- a/src/ast/agents/agent-file-writer.ts
+++ b/src/ast/agents/agent-file-writer.ts
@@ -7,7 +7,7 @@ import { createNameImport } from "../shared/ast-builders";
 import { AGENTS_DIR, AST_IMPORT_PATHS, AST_RUNTIME_CONSTANTS } from "../shared/constants";
 import {
 	type CodegenEnvironment,
-	getCodegenArtifactExtension,
+	codegenArtifactFileName,
 } from "../shared/codegen-environment";
 import { emitValueAsExpression } from "../shared/emit/emit-value-as-expression";
 import {
@@ -230,10 +230,9 @@ export async function createTypescriptFileForAgent(args: {
 		statementSegments,
 		agentFileBasename,
 	});
-	const artifactExtension = getCodegenArtifactExtension(args.environment);
 	const outputPath = path.resolve(
 		AGENTS_DIR,
-		`${agentFileBasename}.${artifactExtension}`,
+		codegenArtifactFileName(agentFileBasename, args.environment),
 	);
 	const content =
 		args.environment === "javascript"

--- a/src/ast/agents/agent-file-writer.ts
+++ b/src/ast/agents/agent-file-writer.ts
@@ -11,10 +11,8 @@ import {
 	finalizeGeneratedSourceWithTrailingNewline,
 	insertBlankLineAfterDoubleSlashBanner,
 	printTsNodes,
-	transpileTsToJs,
 	writeTextArtifact,
 } from "../shared/emit/ts-emit-core";
-import { TS_EMIT_OPTIONS_GENERATED } from "../shared/emit/ts-emit-options";
 
 interface AgentModuleBuildResult {
 	statementSegments: readonly (readonly ts.Statement[])[];
@@ -50,10 +48,10 @@ function addGeneratedAgentModuleBanner(
 	);
 }
 
-function printAndTranspileAgentModule(args: {
+function printAgentModule(args: {
 	statementSegments: readonly (readonly ts.Statement[])[];
 	agentFileBasename: string;
-}): { tsCode: string; jsCode: string } {
+}): { tsCode: string } {
 	const context = createEmitContext({
 		fileName: `${args.agentFileBasename}.ts`,
 	});
@@ -62,12 +60,7 @@ function printAndTranspileAgentModule(args: {
 		.join("\n\n");
 	let tsCode = insertBlankLineAfterDoubleSlashBanner(printed);
 	tsCode = finalizeGeneratedSourceWithTrailingNewline(tsCode);
-	const jsCode = transpileTsToJs({
-		typescriptCode: tsCode,
-		module: TS_EMIT_OPTIONS_GENERATED.module,
-		target: TS_EMIT_OPTIONS_GENERATED.target,
-	});
-	return { tsCode, jsCode };
+	return { tsCode };
 }
 
 function buildAgentModuleNodes(args: {
@@ -200,18 +193,17 @@ export function renderAgentModule(args: {
 	agentModuleName?: string;
 }): {
 	tsCode: string;
-	jsCode: string;
 	agentId: string;
 	agentName: string;
 	agentModuleName: string;
 } {
 	const { statementSegments, agentId, agentName, agentModuleName } =
 		buildAgentModuleNodes(args);
-	const { tsCode, jsCode } = printAndTranspileAgentModule({
+	const { tsCode } = printAgentModule({
 		statementSegments,
 		agentFileBasename: toPascalCase(agentModuleName),
 	});
-	return { tsCode, jsCode, agentId, agentName, agentModuleName };
+	return { tsCode, agentId, agentName, agentModuleName };
 }
 
 export async function createTypescriptFileForAgent(args: {
@@ -227,12 +219,10 @@ export async function createTypescriptFileForAgent(args: {
 	}
 
 	const agentFileBasename = toPascalCase(agentModuleName);
-	const { tsCode, jsCode } = printAndTranspileAgentModule({
+	const { tsCode } = printAgentModule({
 		statementSegments,
 		agentFileBasename,
 	});
 	const tsPath = path.resolve(AGENTS_DIR, `${agentFileBasename}.ts`);
-	const jsPath = path.resolve(AGENTS_DIR, `${agentFileBasename}.js`);
 	writeTextArtifact({ filePath: tsPath, content: tsCode });
-	writeTextArtifact({ filePath: jsPath, content: jsCode });
 }

--- a/src/ast/agents/agent-file-writer.ts
+++ b/src/ast/agents/agent-file-writer.ts
@@ -5,14 +5,20 @@ import type { AgentIcon } from "../../client/agent/AgentClient";
 import { camelize, toPascalCase } from "../../helpers";
 import { createNameImport } from "../shared/ast-builders";
 import { AGENTS_DIR, AST_IMPORT_PATHS, AST_RUNTIME_CONSTANTS } from "../shared/constants";
+import {
+	type CodegenEnvironment,
+	getCodegenArtifactExtension,
+} from "../shared/codegen-environment";
 import { emitValueAsExpression } from "../shared/emit/emit-value-as-expression";
 import {
 	createEmitContext,
 	finalizeGeneratedSourceWithTrailingNewline,
 	insertBlankLineAfterDoubleSlashBanner,
 	printTsNodes,
+	transpileTsToJs,
 	writeTextArtifact,
 } from "../shared/emit/ts-emit-core";
+import { TS_EMIT_OPTIONS_GENERATED } from "../shared/emit/ts-emit-options";
 
 interface AgentModuleBuildResult {
 	statementSegments: readonly (readonly ts.Statement[])[];
@@ -211,6 +217,7 @@ export async function createTypescriptFileForAgent(args: {
 	agentName: string;
 	agentModuleName: string;
 	agentIcon: AgentIcon;
+	environment: CodegenEnvironment;
 }): Promise<void> {
 	const { statementSegments, agentModuleName } = buildAgentModuleNodes(args);
 
@@ -223,6 +230,18 @@ export async function createTypescriptFileForAgent(args: {
 		statementSegments,
 		agentFileBasename,
 	});
-	const tsPath = path.resolve(AGENTS_DIR, `${agentFileBasename}.ts`);
-	writeTextArtifact({ filePath: tsPath, content: tsCode });
+	const artifactExtension = getCodegenArtifactExtension(args.environment);
+	const outputPath = path.resolve(
+		AGENTS_DIR,
+		`${agentFileBasename}.${artifactExtension}`,
+	);
+	const content =
+		args.environment === "javascript"
+			? transpileTsToJs({
+					typescriptCode: tsCode,
+					module: TS_EMIT_OPTIONS_GENERATED.module,
+					target: TS_EMIT_OPTIONS_GENERATED.target,
+				})
+			: tsCode;
+	writeTextArtifact({ filePath: outputPath, content });
 }

--- a/src/ast/agents/generate-agents-cli.ts
+++ b/src/ast/agents/generate-agents-cli.ts
@@ -116,7 +116,7 @@ export const createAgentTypes = async (
 	return { agentNames, skipped: false };
 };
 
-/** Emits `agents/index.ts|js` so generated clients can be imported as a registry. */
+/** Emits `agents/index.ts` so generated clients can be imported as a registry. */
 function createAgentBarrelFile(args: { agentInfo: Array<{ name: string }> }) {
 	const { agentInfo } = args;
 
@@ -124,11 +124,10 @@ function createAgentBarrelFile(args: { agentInfo: Array<{ name: string }> }) {
 		registryName: "agents",
 		entries: agentInfo.map(({ name }) => ({
 			importName: name,
-			importPath: `./${toPascalCase(name)}`,
+			importPath: `./${toPascalCase(name)}.js`,
 			registryKey: name,
 		})),
 		tsPath: path.resolve(AGENTS_DIR, "index.ts"),
-		jsPath: path.resolve(AGENTS_DIR, "index.js"),
 	});
 }
 

--- a/src/ast/agents/generate-agents-cli.ts
+++ b/src/ast/agents/generate-agents-cli.ts
@@ -17,11 +17,11 @@ import {
 	readDatabaseMetadata,
 } from "../shared/cached-metadata";
 import {
-	getCodegenArtifactExtension,
+	codegenArtifactFileName,
 	resolveCodegenEnvironment,
 	type CodegenEnvironment,
 } from "../shared/codegen-environment";
-import { AGENTS_DIR, AST_FS_PATHS } from "../shared/constants";
+import { AGENTS_DIR, AST_FS_PATHS, codegenIndexSourcePath } from "../shared/constants";
 import { updateSourceIndexFile } from "../shared/emit/orm-index-emitter";
 import { emitRegistryModuleArtifacts } from "../shared/emit/registry-emitter";
 import { createTypescriptFileForAgent } from "./agent-file-writer";
@@ -129,17 +129,15 @@ function createAgentBarrelFile(args: {
 	environment: CodegenEnvironment;
 }) {
 	const { agentInfo, environment } = args;
-	const artifactExtension = getCodegenArtifactExtension(environment);
 
 	emitRegistryModuleArtifacts({
 		registryName: "agents",
 		entries: agentInfo.map(({ name }) => ({
 			importName: name,
-			importPath: `./${toPascalCase(name)}.${artifactExtension}`,
+			importPath: `./${codegenArtifactFileName(toPascalCase(name), environment)}`,
 			registryKey: name,
 		})),
-		tsPath: AST_FS_PATHS.agentBarrel("typescript"),
-		jsPath: AST_FS_PATHS.agentBarrel("javascript"),
+		outputPath: codegenIndexSourcePath({ scope: "agents", environment }),
 		environment,
 	});
 }

--- a/src/ast/agents/generate-agents-cli.ts
+++ b/src/ast/agents/generate-agents-cli.ts
@@ -16,6 +16,11 @@ import {
 	type CachedEntityMetadata,
 	readDatabaseMetadata,
 } from "../shared/cached-metadata";
+import {
+	getCodegenArtifactExtension,
+	resolveCodegenEnvironment,
+	type CodegenEnvironment,
+} from "../shared/codegen-environment";
 import { AGENTS_DIR, AST_FS_PATHS } from "../shared/constants";
 import { updateSourceIndexFile } from "../shared/emit/orm-index-emitter";
 import { emitRegistryModuleArtifacts } from "../shared/emit/registry-emitter";
@@ -57,13 +62,13 @@ export const createAgentTypes = async (
 	const client = new sdk.NotionAgentsClient({
 		auth: config.auth,
 	});
+	const configFile = findConfigFile();
+	const environment = resolveCodegenEnvironment({ configRuntime: configFile });
 
 	const agentsList = await client.agents.list({
 		page_size: 100,
 	});
 	options?.onProgress?.({ completed: 0, total: agentsList.results.length });
-
-	const configFile = findConfigFile();
 	if (configFile) {
 		const agentsToSync = agentsList.results.map(({ id, name }) => ({
 			id,
@@ -87,6 +92,7 @@ export const createAgentTypes = async (
 				normalizedIdForStorage,
 				agent.name,
 				parseAgentIcon(agent.icon),
+				environment,
 			);
 			metadataMap.set(agentMetadata.id, agentMetadata);
 			agentNames.push(agentMetadata.displayName);
@@ -106,28 +112,35 @@ export const createAgentTypes = async (
 
 	createAgentBarrelFile({
 		agentInfo: agentsMetadata.map((agent) => ({ name: agent.name })),
+		environment,
 	});
 
 	if (!options?.skipSourceIndexUpdate) {
 		const databasesMetadata = readDatabaseMetadata();
-		updateSourceIndexFile(databasesMetadata, agentsMetadata);
+		updateSourceIndexFile(databasesMetadata, agentsMetadata, environment);
 	}
 
 	return { agentNames, skipped: false };
 };
 
-/** Emits `agents/index.ts` so generated clients can be imported as a registry. */
-function createAgentBarrelFile(args: { agentInfo: Array<{ name: string }> }) {
-	const { agentInfo } = args;
+/** Emits the environment-specific `agents/index` registry module. */
+function createAgentBarrelFile(args: {
+	agentInfo: Array<{ name: string }>;
+	environment: CodegenEnvironment;
+}) {
+	const { agentInfo, environment } = args;
+	const artifactExtension = getCodegenArtifactExtension(environment);
 
 	emitRegistryModuleArtifacts({
 		registryName: "agents",
 		entries: agentInfo.map(({ name }) => ({
 			importName: name,
-			importPath: `./${toPascalCase(name)}.js`,
+			importPath: `./${toPascalCase(name)}.${artifactExtension}`,
 			registryKey: name,
 		})),
-		tsPath: path.resolve(AGENTS_DIR, "index.ts"),
+		tsPath: AST_FS_PATHS.agentBarrel("typescript"),
+		jsPath: AST_FS_PATHS.agentBarrel("javascript"),
+		environment,
 	});
 }
 
@@ -189,6 +202,7 @@ async function generateAgentTypes(
 	agentId: string,
 	agentName: string,
 	agentIcon: AgentIcon,
+	environment: CodegenEnvironment,
 ): Promise<CachedAgentMetadata> {
 	const agentModuleName = camelize(agentName);
 
@@ -197,6 +211,7 @@ async function generateAgentTypes(
 		agentName,
 		agentModuleName,
 		agentIcon,
+		environment,
 	});
 
 	const agentMetadata = createMetadata(agentId, agentModuleName, agentName);

--- a/src/ast/agents/generate-agents-cli.ts
+++ b/src/ast/agents/generate-agents-cli.ts
@@ -4,12 +4,11 @@
  * generated source index when requested.
  */
 import fs from "fs";
-import path from "path";
 import { z } from "zod";
 import { isAgentsSdkAvailable, loadAgentsSdk } from "../../agents-sdk-resolver";
 import { syncAgentsInConfigWithAST } from "../../cli/helpers";
 import type { AgentIcon } from "../../client/agent/AgentClient";
-import { findConfigFile } from "../../config/helpers";
+import { findConfigFile } from "../../config/findConfigFile";
 import { getNotionConfig } from "../../config/loadConfig";
 import { camelize, toPascalCase, toUndashedNotionId } from "../../helpers";
 import {
@@ -45,6 +44,8 @@ type CreateAgentTypesOptions = {
 
 export type CreateAgentTypesResult = {
 	agentNames: string[];
+	/** Module/registry keys (camelCase), parallel to `agentNames`. */
+	agentKeys: string[];
 	skipped: boolean;
 };
 
@@ -53,7 +54,7 @@ export const createAgentTypes = async (
 	options?: CreateAgentTypesOptions,
 ): Promise<CreateAgentTypesResult> => {
 	if (!isAgentsSdkAvailable()) {
-		return { agentNames: [], skipped: true };
+		return { agentNames: [], agentKeys: [], skipped: true };
 	}
 
 	const sdk = await loadAgentsSdk();
@@ -83,6 +84,7 @@ export const createAgentTypes = async (
 
 	const metadataMap = new Map<string, CachedAgentMetadata>();
 	const agentNames: string[] = [];
+	const agentKeys: string[] = [];
 	let completedCount = 0;
 
 	for (const agent of agentsList.results) {
@@ -96,6 +98,7 @@ export const createAgentTypes = async (
 			);
 			metadataMap.set(agentMetadata.id, agentMetadata);
 			agentNames.push(agentMetadata.displayName);
+			agentKeys.push(agentMetadata.name);
 			completedCount += 1;
 			options?.onProgress?.({
 				completed: completedCount,
@@ -120,7 +123,7 @@ export const createAgentTypes = async (
 		updateSourceIndexFile(databasesMetadata, agentsMetadata, environment);
 	}
 
-	return { agentNames, skipped: false };
+	return { agentNames, agentKeys, skipped: false };
 };
 
 /** Emits the environment-specific `agents/index` registry module. */

--- a/src/ast/database/database-file-writer.ts
+++ b/src/ast/database/database-file-writer.ts
@@ -37,8 +37,14 @@ import {
 	createEmitContext,
 	finalizeGeneratedSourceWithTrailingNewline,
 	printTsNodes,
+	transpileTsToJs,
 	writeTextArtifact,
 } from "../shared/emit/ts-emit-core";
+import {
+	type CodegenEnvironment,
+	getCodegenArtifactExtension,
+} from "../shared/codegen-environment";
+import { TS_EMIT_OPTIONS_GENERATED } from "../shared/emit/ts-emit-options";
 import {
 	propertyASTGenerators,
 	type SupportedNotionProperty,
@@ -113,7 +119,7 @@ function insertBlankLineAfterGeneratedBanner(code: string): string {
 	);
 }
 
-function printAndTranspileDatabaseModule(args: {
+function printDatabaseModule(args: {
 	statementSegments: readonly (readonly ts.Statement[])[];
 	databaseFileBasename: string;
 }): { tsCode: string } {
@@ -304,7 +310,7 @@ function buildDatabaseModuleNodes(
 	}
 
 /**
- * Renders the generated database module to TS and JS source text without
+ * Renders the generated database module to TypeScript source text without
  * writing to disk. Used by golden tests and any caller that needs the
  * emitted code as strings.
  */
@@ -318,7 +324,7 @@ export function renderDatabaseModule(
 } {
 	const { statementSegments, databaseName, databaseModuleName, databaseId } =
 		buildDatabaseModuleNodes(dataSourceResponse);
-	const { tsCode } = printAndTranspileDatabaseModule({
+	const { tsCode } = printDatabaseModule({
 		statementSegments,
 		databaseFileBasename: toPascalCase(databaseModuleName),
 	});
@@ -329,9 +335,13 @@ export function renderDatabaseModule(
  * Creates the generated module for a single database and writes it to disk.
  * Thin wrapper over the pure builders that adds filesystem I/O.
  */
-export async function createTypescriptFileForDatabase(
-	dataSourceResponse: GetDataSourceResponse,
+export async function createCodegenFileForDatabase(
+	args: {
+		dataSourceResponse: GetDataSourceResponse;
+		environment: CodegenEnvironment;
+	},
 ) {
+	const { dataSourceResponse, environment } = args;
 	const { statementSegments, databaseName, databaseModuleName, databaseId } =
 		buildDatabaseModuleNodes(dataSourceResponse);
 
@@ -341,12 +351,24 @@ export async function createTypescriptFileForDatabase(
 	}
 
 	const databaseFileBasename = toPascalCase(databaseModuleName);
-	const { tsCode } = printAndTranspileDatabaseModule({
+	const { tsCode } = printDatabaseModule({
 		statementSegments,
 		databaseFileBasename,
 	});
-	const tsPath = path.resolve(databasesDir, `${databaseFileBasename}.ts`);
-	writeTextArtifact({ filePath: tsPath, content: tsCode });
+	const artifactExtension = getCodegenArtifactExtension(environment);
+	const outputPath = path.resolve(
+		databasesDir,
+		`${databaseFileBasename}.${artifactExtension}`,
+	);
+	const content =
+		environment === "javascript"
+			? transpileTsToJs({
+					typescriptCode: tsCode,
+					module: TS_EMIT_OPTIONS_GENERATED.module,
+					target: TS_EMIT_OPTIONS_GENERATED.target,
+				})
+			: tsCode;
+	writeTextArtifact({ filePath: outputPath, content });
 
 	return {
 		databaseName,

--- a/src/ast/database/database-file-writer.ts
+++ b/src/ast/database/database-file-writer.ts
@@ -42,7 +42,7 @@ import {
 } from "../shared/emit/ts-emit-core";
 import {
 	type CodegenEnvironment,
-	getCodegenArtifactExtension,
+	codegenArtifactFileName,
 } from "../shared/codegen-environment";
 import { TS_EMIT_OPTIONS_GENERATED } from "../shared/emit/ts-emit-options";
 import {
@@ -355,10 +355,9 @@ export async function createCodegenFileForDatabase(
 		statementSegments,
 		databaseFileBasename,
 	});
-	const artifactExtension = getCodegenArtifactExtension(environment);
 	const outputPath = path.resolve(
 		databasesDir,
-		`${databaseFileBasename}.${artifactExtension}`,
+		codegenArtifactFileName(databaseFileBasename, environment),
 	);
 	const content =
 		environment === "javascript"

--- a/src/ast/database/database-file-writer.ts
+++ b/src/ast/database/database-file-writer.ts
@@ -37,10 +37,8 @@ import {
 	createEmitContext,
 	finalizeGeneratedSourceWithTrailingNewline,
 	printTsNodes,
-	transpileTsToJs,
 	writeTextArtifact,
 } from "../shared/emit/ts-emit-core";
-import { TS_EMIT_OPTIONS_GENERATED } from "../shared/emit/ts-emit-options";
 import {
 	propertyASTGenerators,
 	type SupportedNotionProperty,
@@ -118,7 +116,7 @@ function insertBlankLineAfterGeneratedBanner(code: string): string {
 function printAndTranspileDatabaseModule(args: {
 	statementSegments: readonly (readonly ts.Statement[])[];
 	databaseFileBasename: string;
-}): { tsCode: string; jsCode: string } {
+}): { tsCode: string } {
 	const context = createEmitContext({
 		fileName: `${args.databaseFileBasename}.ts`,
 	});
@@ -127,12 +125,7 @@ function printAndTranspileDatabaseModule(args: {
 		.join("\n\n");
 	let tsCode = insertBlankLineAfterGeneratedBanner(printed);
 	tsCode = finalizeGeneratedSourceWithTrailingNewline(tsCode);
-	const jsCode = transpileTsToJs({
-		typescriptCode: tsCode,
-		module: TS_EMIT_OPTIONS_GENERATED.module,
-		target: TS_EMIT_OPTIONS_GENERATED.target,
-	});
-	return { tsCode, jsCode };
+	return { tsCode };
 }
 
 /**
@@ -319,18 +312,17 @@ export function renderDatabaseModule(
 	dataSourceResponse: GetDataSourceResponse,
 ): {
 	tsCode: string;
-	jsCode: string;
 	databaseName: string;
 	databaseModuleName: string;
 	databaseId: string;
 } {
 	const { statementSegments, databaseName, databaseModuleName, databaseId } =
 		buildDatabaseModuleNodes(dataSourceResponse);
-	const { tsCode, jsCode } = printAndTranspileDatabaseModule({
+	const { tsCode } = printAndTranspileDatabaseModule({
 		statementSegments,
 		databaseFileBasename: toPascalCase(databaseModuleName),
 	});
-	return { tsCode, jsCode, databaseName, databaseModuleName, databaseId };
+	return { tsCode, databaseName, databaseModuleName, databaseId };
 }
 
 /**
@@ -349,14 +341,12 @@ export async function createTypescriptFileForDatabase(
 	}
 
 	const databaseFileBasename = toPascalCase(databaseModuleName);
-	const { tsCode, jsCode } = printAndTranspileDatabaseModule({
+	const { tsCode } = printAndTranspileDatabaseModule({
 		statementSegments,
 		databaseFileBasename,
 	});
 	const tsPath = path.resolve(databasesDir, `${databaseFileBasename}.ts`);
-	const jsPath = path.resolve(databasesDir, `${databaseFileBasename}.js`);
 	writeTextArtifact({ filePath: tsPath, content: tsCode });
-	writeTextArtifact({ filePath: jsPath, content: jsCode });
 
 	return {
 		databaseName,

--- a/src/ast/database/generate-databases-cli.ts
+++ b/src/ast/database/generate-databases-cli.ts
@@ -14,11 +14,15 @@ import {
 	readDatabaseMetadata,
 } from "../shared/cached-metadata";
 import {
-	getCodegenArtifactExtension,
+	codegenArtifactFileName,
 	resolveCodegenEnvironment,
 	type CodegenEnvironment,
 } from "../shared/codegen-environment";
-import { AST_FS_PATHS, AST_RUNTIME_CONSTANTS } from "../shared/constants";
+import {
+	AST_FS_PATHS,
+	AST_RUNTIME_CONSTANTS,
+	codegenIndexSourcePath,
+} from "../shared/constants";
 import { updateSourceIndexFile } from "../shared/emit/orm-index-emitter";
 import { emitRegistryModuleArtifacts } from "../shared/emit/registry-emitter";
 import { createCodegenFileForDatabase } from "./database-file-writer";
@@ -138,17 +142,15 @@ function createDatabaseBarrelFile(args: {
 	environment: CodegenEnvironment;
 }) {
 	const { databaseInfo, environment } = args;
-	const artifactExtension = getCodegenArtifactExtension(environment);
 
 	emitRegistryModuleArtifacts({
 		registryName: "databases",
 		entries: databaseInfo.map(({ name }) => ({
 			importName: toPascalCase(name),
-			importPath: `./${toPascalCase(name)}.${artifactExtension}`,
+			importPath: `./${codegenArtifactFileName(toPascalCase(name), environment)}`,
 			registryKey: name,
 		})),
-		tsPath: AST_FS_PATHS.databaseBarrelTs,
-		jsPath: AST_FS_PATHS.databaseBarrelJs,
+		outputPath: codegenIndexSourcePath({ scope: "databases", environment }),
 		environment,
 	});
 }

--- a/src/ast/database/generate-databases-cli.ts
+++ b/src/ast/database/generate-databases-cli.ts
@@ -13,10 +13,15 @@ import {
 	readAgentMetadataFromDisk,
 	readDatabaseMetadata,
 } from "../shared/cached-metadata";
+import {
+	getCodegenArtifactExtension,
+	resolveCodegenEnvironment,
+	type CodegenEnvironment,
+} from "../shared/codegen-environment";
 import { AST_FS_PATHS, AST_RUNTIME_CONSTANTS } from "../shared/constants";
 import { updateSourceIndexFile } from "../shared/emit/orm-index-emitter";
 import { emitRegistryModuleArtifacts } from "../shared/emit/registry-emitter";
-import { createTypescriptFileForDatabase } from "./database-file-writer";
+import { createCodegenFileForDatabase } from "./database-file-writer";
 
 function writeDatabaseMetadata(metadata: CachedEntityMetadata[]): void {
 	const databasesDir = AST_FS_PATHS.DATABASES_DIR;
@@ -46,6 +51,7 @@ export const createDatabaseTypes = async (
 	options: CreateDatabaseTypesArgs,
 ): Promise<{ databaseNames: string[]; databaseKeys: string[] }> => {
 	const config = await getNotionConfig();
+	const environment = resolveCodegenEnvironment();
 
 	const client = new Client({
 		auth: config.auth,
@@ -74,10 +80,10 @@ export const createDatabaseTypes = async (
 
 	if (targetIds.length === 0) {
 		writeDatabaseMetadata([]);
-		createDatabaseBarrelFile({ databaseInfo: [] });
+		createDatabaseBarrelFile({ databaseInfo: [], environment });
 		if (!options.skipSourceIndexUpdate) {
 			const agentsMetadata = readAgentMetadataFromDisk();
-			updateSourceIndexFile([], agentsMetadata);
+			updateSourceIndexFile([], agentsMetadata, environment);
 		}
 		return { databaseNames: [], databaseKeys: [] };
 	}
@@ -88,7 +94,11 @@ export const createDatabaseTypes = async (
 
 	for (const databaseId of targetIds) {
 		try {
-			const databaseMetadata = await generateDatabaseTypes(client, databaseId);
+			const databaseMetadata = await generateDatabaseTypes(
+				client,
+				databaseId,
+				environment,
+			);
 			metadataMap.set(databaseMetadata.id, databaseMetadata);
 			databaseNames.push(databaseMetadata.displayName);
 			databaseKeys.push(databaseMetadata.name);
@@ -111,11 +121,12 @@ export const createDatabaseTypes = async (
 
 	createDatabaseBarrelFile({
 		databaseInfo: databasesMetadata.map((db) => ({ name: db.name })),
+		environment,
 	});
 
 	if (!options.skipSourceIndexUpdate) {
 		const agentsMetadata = readAgentMetadataFromDisk();
-		updateSourceIndexFile(databasesMetadata, agentsMetadata);
+		updateSourceIndexFile(databasesMetadata, agentsMetadata, environment);
 	}
 
 	return { databaseNames, databaseKeys };
@@ -124,17 +135,21 @@ export const createDatabaseTypes = async (
 /** Emits `databases/index.ts` so generated databases can be addressed as a registry. */
 function createDatabaseBarrelFile(args: {
 	databaseInfo: Array<{ name: string }>;
+	environment: CodegenEnvironment;
 }) {
-	const { databaseInfo } = args;
+	const { databaseInfo, environment } = args;
+	const artifactExtension = getCodegenArtifactExtension(environment);
 
 	emitRegistryModuleArtifacts({
 		registryName: "databases",
 		entries: databaseInfo.map(({ name }) => ({
 			importName: toPascalCase(name),
-			importPath: `./${toPascalCase(name)}.js`,
+			importPath: `./${toPascalCase(name)}.${artifactExtension}`,
 			registryKey: name,
 		})),
 		tsPath: AST_FS_PATHS.databaseBarrelTs,
+		jsPath: AST_FS_PATHS.databaseBarrelJs,
+		environment,
 	});
 }
 
@@ -154,16 +169,17 @@ function createMetadata(
 async function generateDatabaseTypes(
 	client: Client,
 	databaseId: string,
+	environment: CodegenEnvironment,
 ): Promise<CachedEntityMetadata> {
 	const databaseObject = await client.dataSources.retrieve({
 		data_source_id: databaseId,
 	});
 
-	const {
-		databaseModuleName,
-		databaseName,
-		databaseId: id,
-	} = await createTypescriptFileForDatabase(databaseObject);
+	const { databaseModuleName, databaseName, databaseId: id } =
+		await createCodegenFileForDatabase({
+			dataSourceResponse: databaseObject,
+			environment,
+		});
 
 	return createMetadata(id, databaseModuleName, databaseName);
 }

--- a/src/ast/database/generate-databases-cli.ts
+++ b/src/ast/database/generate-databases-cli.ts
@@ -121,7 +121,7 @@ export const createDatabaseTypes = async (
 	return { databaseNames, databaseKeys };
 };
 
-/** Emits `databases/index.ts|js` so generated databases can be addressed as a registry. */
+/** Emits `databases/index.ts` so generated databases can be addressed as a registry. */
 function createDatabaseBarrelFile(args: {
 	databaseInfo: Array<{ name: string }>;
 }) {
@@ -131,11 +131,10 @@ function createDatabaseBarrelFile(args: {
 		registryName: "databases",
 		entries: databaseInfo.map(({ name }) => ({
 			importName: toPascalCase(name),
-			importPath: `./${toPascalCase(name)}`,
+			importPath: `./${toPascalCase(name)}.js`,
 			registryKey: name,
 		})),
 		tsPath: AST_FS_PATHS.databaseBarrelTs,
-		jsPath: AST_FS_PATHS.databaseBarrelJs,
 	});
 }
 

--- a/src/ast/shared/codegen-environment.ts
+++ b/src/ast/shared/codegen-environment.ts
@@ -1,3 +1,24 @@
+/**
+ * Codegen extension rules (central source of truth for TS vs JS choices):
+ *
+ *   Rule 1 (env-driven). Per-file ARTIFACT extension is `.ts` or `.js` based
+ *            on the consumer project's environment. Compose filenames with
+ *            `codegenArtifactFileName(basename, env)` (or
+ *            `getCodegenArtifactExtension(env)` only when you need the raw
+ *            extension) — never inline the TS/JS ternary.
+ *   Rule 2 (constant).   Relative IMPORT SPECIFIERS inside generated `.ts`
+ *            and `.d.ts` modules are always `.js` (TS ESM NodeNext pattern
+ *            so emitted JS and Node resolution line up). Use
+ *            `getCodegenImportExtension()`.
+ *   Rule 3 (constant).   DECLARATION artifacts are always `.d.ts` /
+ *            `.d.ts.map` regardless of environment (see
+ *            `AST_FS_FILENAMES.INDEX_DTS` / `INDEX_DTS_MAP`).
+ *
+ * New env-dependent file locations should go through
+ * `codegenIndexSourcePath` (for `index.{ts,js}`-shaped outputs) rather than
+ * reintroducing `Ts`/`Js` paired constants.
+ */
+
 import fs from "fs";
 import path from "path";
 
@@ -35,6 +56,18 @@ export function getCodegenArtifactExtension(
 	environment: CodegenEnvironment,
 ): "ts" | "js" {
 	return environment === "typescript" ? "ts" : "js";
+}
+
+/**
+ * Environment-aware artifact filename: `{basename}.{ts|js}`.
+ * Use for on-disk module paths and relative `./Foo.{ts|js}` import paths in
+ * emitted registries — do not interpolate `getCodegenArtifactExtension` by hand.
+ */
+export function codegenArtifactFileName(
+	basename: string,
+	environment: CodegenEnvironment,
+): string {
+	return `${basename}.${getCodegenArtifactExtension(environment)}`;
 }
 
 export function getCodegenImportExtension(): "js" {

--- a/src/ast/shared/codegen-environment.ts
+++ b/src/ast/shared/codegen-environment.ts
@@ -24,7 +24,7 @@ import path from "path";
 
 export type CodegenEnvironment = "typescript" | "javascript";
 
-export type CodegenConfigRuntime = {
+type CodegenConfigRuntime = {
 	isTS: boolean;
 };
 
@@ -52,7 +52,7 @@ export function resolveCodegenEnvironment(args?: {
 	return hasTypeScriptConfig(projectRoot) ? "typescript" : "javascript";
 }
 
-export function getCodegenArtifactExtension(
+function getCodegenArtifactExtension(
 	environment: CodegenEnvironment,
 ): "ts" | "js" {
 	return environment === "typescript" ? "ts" : "js";

--- a/src/ast/shared/codegen-environment.ts
+++ b/src/ast/shared/codegen-environment.ts
@@ -1,0 +1,42 @@
+import fs from "fs";
+import path from "path";
+
+export type CodegenEnvironment = "typescript" | "javascript";
+
+export type CodegenConfigRuntime = {
+	isTS: boolean;
+};
+
+const TSCONFIG_CANDIDATES = [
+	"tsconfig.json",
+	"tsconfig.app.json",
+	"tsconfig.base.json",
+	"tsconfig.build.json",
+] as const;
+
+function hasTypeScriptConfig(projectRoot: string): boolean {
+	return TSCONFIG_CANDIDATES.some((candidate) =>
+		fs.existsSync(path.join(projectRoot, candidate)),
+	);
+}
+
+export function resolveCodegenEnvironment(args?: {
+	projectRoot?: string;
+	configRuntime?: CodegenConfigRuntime;
+}): CodegenEnvironment {
+	const projectRoot = args?.projectRoot ?? process.cwd();
+	if (args?.configRuntime?.isTS) {
+		return "typescript";
+	}
+	return hasTypeScriptConfig(projectRoot) ? "typescript" : "javascript";
+}
+
+export function getCodegenArtifactExtension(
+	environment: CodegenEnvironment,
+): "ts" | "js" {
+	return environment === "typescript" ? "ts" : "js";
+}
+
+export function getCodegenImportExtension(): "js" {
+	return "js";
+}

--- a/src/ast/shared/constants.ts
+++ b/src/ast/shared/constants.ts
@@ -10,7 +10,8 @@ import { toPascalCase } from "../../helpers";
  * Top-level directory name for CLI-generated artifacts in consuming projects
  * (`notion/` entry + `databases/`, `agents/`). Prefer **`import { NotionORM } from "./notion/"`**
  * in apps (directory import resolves to `index` — no need to spell `index`). Distinct from this package's
- * npm `outDir` (`build/`), which remains `@haustle/notion-orm/build/...`.
+ * npm `outDir` (`build/`), which is hidden behind stable package exports such as
+ * `@haustle/notion-orm/base`.
  */
 const PROJECT_CODEGEN_DIR_NAME = "notion" as const;
 
@@ -61,10 +62,6 @@ export const AST_FS_PATHS = {
 		return path.resolve(AST_FS_PATHS.CODEGEN_ROOT_DIR, AST_FS_FILENAMES.INDEX_TS);
 	},
 
-	get buildIndexJs(): string {
-		return path.resolve(AST_FS_PATHS.CODEGEN_ROOT_DIR, AST_FS_FILENAMES.INDEX_JS);
-	},
-
 	get buildIndexDts(): string {
 		return path.resolve(AST_FS_PATHS.CODEGEN_ROOT_DIR, AST_FS_FILENAMES.INDEX_DTS);
 	},
@@ -80,16 +77,12 @@ export const AST_FS_PATHS = {
 		return path.resolve(getDatabasesDir(), AST_FS_FILENAMES.INDEX_TS);
 	},
 
-	get databaseBarrelJs(): string {
-		return path.resolve(getDatabasesDir(), AST_FS_FILENAMES.INDEX_JS);
-	},
 } as const;
 
 /** Shared filenames used across emitted artifacts. */
 const AST_FS_FILENAMES = {
 	METADATA: "metadata.json",
 	INDEX_TS: "index.ts",
-	INDEX_JS: "index.js",
 	INDEX_DTS: "index.d.ts",
 	INDEX_DTS_MAP: "index.d.ts.map",
 } as const;
@@ -99,16 +92,16 @@ export const AST_IMPORT_PATHS = {
 	DATABASE_CLIENT: "@haustle/notion-orm",
 	AGENT_CLIENT: "@haustle/notion-orm",
 	QUERY_TYPES: "@haustle/notion-orm",
-	ORM_BASE: "@haustle/notion-orm/build/src/base",
+	ORM_BASE: "@haustle/notion-orm/base",
 
 	ZOD: "zod",
 
 	databaseClass(name: string): string {
-		return `./${PROJECT_DATABASES_DIR_NAME}/${toPascalCase(name)}`;
+		return `./${PROJECT_DATABASES_DIR_NAME}/${toPascalCase(name)}.js`;
 	},
 
 	agentClass(name: string): string {
-		return `./agents/${toPascalCase(name)}`;
+		return `./agents/${toPascalCase(name)}.js`;
 	},
 } as const;
 
@@ -170,7 +163,7 @@ export const PLAYGROUND_PATHS = {
 	MOCK_PACKAGE_INDEX: "playground_modules/haustle-notion-orm/index.ts",
 	MOCK_PACKAGE_NOTION_ID_PATTERNS:
 		"playground_modules/haustle-notion-orm/notion-id-patterns.ts",
-	MOCK_PACKAGE_BASE: "playground_modules/haustle-notion-orm/build/src/base.ts",
+	MOCK_PACKAGE_BASE: "playground_modules/haustle-notion-orm/base.ts",
 	MOCK_PACKAGE_PREFIX: "playground_modules/",
 
 	DEMO_AUTH_PLACEHOLDER: "my-notion-api-key",

--- a/src/ast/shared/constants.ts
+++ b/src/ast/shared/constants.ts
@@ -5,6 +5,7 @@
  */
 import path from "path";
 import { toPascalCase } from "../../helpers";
+import { PACKAGE_RUNTIME_CONSTANTS } from "../../runtime-constants";
 import {
 	codegenArtifactFileName,
 	type CodegenEnvironment,
@@ -24,7 +25,7 @@ const PROJECT_DATABASES_DIR_NAME = "databases" as const;
 
 /**
  * Resolve generated artifact paths from the current project root, not from the
- * installed package location. This keeps `bun notion sync` writing into the
+ * installed package location. This keeps `notion sync` writing into the
  * consuming app when the package is linked locally.
  */
 function getProjectBuildDir(): string {
@@ -125,19 +126,11 @@ export const AST_IMPORT_PATHS = {
 	},
 } as const;
 
-/** Runtime constants shared by emitted clients and CLI flows. */
-export const AST_RUNTIME_CONSTANTS = {
-	NOTION_API_VERSION: "2026-03-11",
-
-	PACKAGE_LOG_PREFIX: "[@haustle/notion-orm]",
-
-	CLI_GENERATE_COMMAND: "notion sync",
-
-	SCHEMA_DRIFT_PREFIX: "Schema drift detected",
-
-	SCHEMA_DRIFT_HELP_MESSAGE:
-		"To easily fix this, please run `notion sync` to refresh all database schemas.",
-} as const;
+/**
+ * Backward-compatible alias for shared runtime constants.
+ * New runtime code should prefer importing from `src/runtime-constants.ts`.
+ */
+export const AST_RUNTIME_CONSTANTS = PACKAGE_RUNTIME_CONSTANTS;
 
 /** Canonical generated type names referenced across emitters. */
 export const AST_TYPE_NAMES = {

--- a/src/ast/shared/constants.ts
+++ b/src/ast/shared/constants.ts
@@ -5,6 +5,10 @@
  */
 import path from "path";
 import { toPascalCase } from "../../helpers";
+import {
+	codegenArtifactFileName,
+	type CodegenEnvironment,
+} from "./codegen-environment";
 
 /**
  * Top-level directory name for CLI-generated artifacts in consuming projects
@@ -58,14 +62,6 @@ export const AST_FS_PATHS = {
 		return path.resolve(getAgentsDir(), AST_FS_FILENAMES.METADATA);
 	},
 
-	get buildIndexTs(): string {
-		return path.resolve(AST_FS_PATHS.CODEGEN_ROOT_DIR, AST_FS_FILENAMES.INDEX_TS);
-	},
-
-	get buildIndexJs(): string {
-		return path.resolve(AST_FS_PATHS.CODEGEN_ROOT_DIR, AST_FS_FILENAMES.INDEX_JS);
-	},
-
 	get buildIndexDts(): string {
 		return path.resolve(AST_FS_PATHS.CODEGEN_ROOT_DIR, AST_FS_FILENAMES.INDEX_DTS);
 	},
@@ -76,37 +72,37 @@ export const AST_FS_PATHS = {
 			AST_FS_FILENAMES.INDEX_DTS_MAP,
 		);
 	},
-
-	get databaseBarrelTs(): string {
-		return path.resolve(getDatabasesDir(), AST_FS_FILENAMES.INDEX_TS);
-	},
-
-	get databaseBarrelJs(): string {
-		return path.resolve(getDatabasesDir(), AST_FS_FILENAMES.INDEX_JS);
-	},
-
-	agentBarrel(environment: "typescript" | "javascript"): string {
-		return path.resolve(
-			getAgentsDir(),
-			environment === "typescript"
-				? AST_FS_FILENAMES.INDEX_TS
-				: AST_FS_FILENAMES.INDEX_JS,
-		);
-	},
-
-	databaseBarrel(environment: "typescript" | "javascript"): string {
-		return environment === "typescript"
-			? AST_FS_PATHS.databaseBarrelTs
-			: AST_FS_PATHS.databaseBarrelJs;
-	},
-
 } as const;
+
+/**
+ * Named locations where an environment-specific `index.ts` / `index.js` is emitted.
+ * Scopes are the keys of `CODEGEN_INDEX_DIR_RESOLVERS` only (AGENTS.md: derive unions from maps).
+ */
+const CODEGEN_INDEX_DIR_RESOLVERS = {
+	codegenRoot: getProjectBuildDir,
+	databases: getDatabasesDir,
+	agents: getAgentsDir,
+} as const satisfies Record<string, () => string>;
+
+export type CodegenIndexScope = keyof typeof CODEGEN_INDEX_DIR_RESOLVERS;
+
+/**
+ * Canonical filesystem path for a generated `index.{ts,js}` source file.
+ * Centralizes the "where does the environment-specific barrel live" rule so
+ * callers never branch on TS vs JS filenames directly.
+ */
+export function codegenIndexSourcePath(args: {
+	scope: CodegenIndexScope;
+	environment: CodegenEnvironment;
+}): string {
+	const { scope, environment } = args;
+	const dir = CODEGEN_INDEX_DIR_RESOLVERS[scope]();
+	return path.join(dir, codegenArtifactFileName("index", environment));
+}
 
 /** Shared filenames used across emitted artifacts. */
 const AST_FS_FILENAMES = {
 	METADATA: "metadata.json",
-	INDEX_TS: "index.ts",
-	INDEX_JS: "index.js",
 	INDEX_DTS: "index.d.ts",
 	INDEX_DTS_MAP: "index.d.ts.map",
 } as const;

--- a/src/ast/shared/constants.ts
+++ b/src/ast/shared/constants.ts
@@ -84,7 +84,7 @@ const CODEGEN_INDEX_DIR_RESOLVERS = {
 	agents: getAgentsDir,
 } as const satisfies Record<string, () => string>;
 
-export type CodegenIndexScope = keyof typeof CODEGEN_INDEX_DIR_RESOLVERS;
+type CodegenIndexScope = keyof typeof CODEGEN_INDEX_DIR_RESOLVERS;
 
 /**
  * Canonical filesystem path for a generated `index.{ts,js}` source file.

--- a/src/ast/shared/constants.ts
+++ b/src/ast/shared/constants.ts
@@ -62,6 +62,10 @@ export const AST_FS_PATHS = {
 		return path.resolve(AST_FS_PATHS.CODEGEN_ROOT_DIR, AST_FS_FILENAMES.INDEX_TS);
 	},
 
+	get buildIndexJs(): string {
+		return path.resolve(AST_FS_PATHS.CODEGEN_ROOT_DIR, AST_FS_FILENAMES.INDEX_JS);
+	},
+
 	get buildIndexDts(): string {
 		return path.resolve(AST_FS_PATHS.CODEGEN_ROOT_DIR, AST_FS_FILENAMES.INDEX_DTS);
 	},
@@ -77,12 +81,32 @@ export const AST_FS_PATHS = {
 		return path.resolve(getDatabasesDir(), AST_FS_FILENAMES.INDEX_TS);
 	},
 
+	get databaseBarrelJs(): string {
+		return path.resolve(getDatabasesDir(), AST_FS_FILENAMES.INDEX_JS);
+	},
+
+	agentBarrel(environment: "typescript" | "javascript"): string {
+		return path.resolve(
+			getAgentsDir(),
+			environment === "typescript"
+				? AST_FS_FILENAMES.INDEX_TS
+				: AST_FS_FILENAMES.INDEX_JS,
+		);
+	},
+
+	databaseBarrel(environment: "typescript" | "javascript"): string {
+		return environment === "typescript"
+			? AST_FS_PATHS.databaseBarrelTs
+			: AST_FS_PATHS.databaseBarrelJs;
+	},
+
 } as const;
 
 /** Shared filenames used across emitted artifacts. */
 const AST_FS_FILENAMES = {
 	METADATA: "metadata.json",
 	INDEX_TS: "index.ts",
+	INDEX_JS: "index.js",
 	INDEX_DTS: "index.d.ts",
 	INDEX_DTS_MAP: "index.d.ts.map",
 } as const;

--- a/src/ast/shared/emit/config-emitter.ts
+++ b/src/ast/shared/emit/config-emitter.ts
@@ -2,6 +2,8 @@ import generate from "@babel/generator";
 import * as parser from "@babel/parser";
 import * as t from "@babel/types";
 import * as ts from "typescript";
+import { NOTION_CONFIG_BASENAME } from "../../../config/notion-config-filenames";
+import { codegenArtifactFileName } from "../codegen-environment";
 import {
 	createEmitContext,
 	printTsNodes,
@@ -167,7 +169,9 @@ export function renderConfigTemplateModule(args: {
 }): string {
 	const {
 		isTS,
-		context = createEmitContext({ fileName: "notion.config.ts" }),
+		context = createEmitContext({
+			fileName: codegenArtifactFileName(NOTION_CONFIG_BASENAME, "typescript"),
+		}),
 	} = args;
 	return printTsNodes({
 		nodes: buildConfigTemplateModuleAst({ isTS }),

--- a/src/ast/shared/emit/orm-index-emitter.ts
+++ b/src/ast/shared/emit/orm-index-emitter.ts
@@ -8,13 +8,20 @@ import {
 	AST_RUNTIME_CONSTANTS,
 } from "../constants";
 import {
+	type CodegenEnvironment,
+	getCodegenArtifactExtension,
+	getCodegenImportExtension,
+} from "../codegen-environment";
+import {
 	createEmitContext,
 	finalizeGeneratedSourceWithTrailingNewline,
 	insertBlankLineAfterDoubleSlashBanner,
 	printTsNodeSegments,
 	type TsEmitContext,
+	transpileTsToJs,
 	writeTextArtifact,
 } from "./ts-emit-core";
+import { TS_EMIT_INTEROP, TS_EMIT_OPTIONS_DEFAULT } from "./ts-emit-options";
 
 /**
  * Minimal metadata needed to wire generated databases/agents into NotionORM.
@@ -483,22 +490,39 @@ function buildOrmIndexModuleStatementSegments(args: {
 	databases: OrmEntityMetadata[];
 	agents: OrmEntityMetadata[];
 	syncCommand: string;
+	environment?: CodegenEnvironment;
 	importPaths?: {
 		databaseClass?: (name: string) => string;
 		agentClass?: (name: string) => string;
 	};
 }): readonly (readonly ts.Statement[])[] {
-	const { databases, agents, syncCommand, importPaths } = args;
+	const {
+		databases,
+		agents,
+		syncCommand,
+		environment = "typescript",
+		importPaths,
+	} = args;
 	const hasAgents = agents.length > 0;
+	const runtimeImportPathFactory = {
+		databaseClass:
+			importPaths?.databaseClass ??
+			((name: string) =>
+				`./databases/${toPascalCase(name)}.${getCodegenImportExtension()}`),
+		agentClass:
+			importPaths?.agentClass ??
+			((name: string) =>
+				`./agents/${toPascalCase(name)}.${getCodegenImportExtension()}`),
+	};
 	const databaseImports = createEntityImportStatements({
 		entities: databases,
-		pathFactory: importPaths?.databaseClass ?? AST_IMPORT_PATHS.databaseClass,
+		pathFactory: runtimeImportPathFactory.databaseClass,
 		factoryExportId: toPascalCase,
 	});
 	const agentImports = hasAgents
 		? createEntityImportStatements({
 				entities: agents,
-				pathFactory: importPaths?.agentClass ?? AST_IMPORT_PATHS.agentClass,
+				pathFactory: runtimeImportPathFactory.agentClass,
 				factoryExportId: toPascalCase,
 			})
 		: [];
@@ -556,6 +580,7 @@ export function buildOrmIndexModuleAst(args: {
 	databases: OrmEntityMetadata[];
 	agents: OrmEntityMetadata[];
 	syncCommand: string;
+	environment?: CodegenEnvironment;
 	importPaths?: {
 		databaseClass?: (name: string) => string;
 		agentClass?: (name: string) => string;
@@ -651,30 +676,44 @@ export function buildOrmIndexDeclarationAst(args: {
 export function emitOrmIndexArtifacts(args: {
 	databases: OrmEntityMetadata[];
 	agents: OrmEntityMetadata[];
-	buildIndexTsPath: string;
+	buildIndexPath: string;
 	buildIndexDtsPath: string;
 	buildIndexDtsMapPath?: string;
 	syncCommand: string;
+	environment: CodegenEnvironment;
 	context?: TsEmitContext;
-}): { tsCode: string; dtsCode: string } {
+}): { code: string; dtsCode: string } {
 	const {
 		databases,
 		agents,
-		buildIndexTsPath,
+		buildIndexPath,
 		buildIndexDtsPath,
 		buildIndexDtsMapPath,
 		syncCommand,
+		environment,
 		context = createEmitContext({ fileName: "index.ts" }),
 	} = args;
 	const runtimeSegments = buildOrmIndexModuleStatementSegments({
 		databases,
 		agents,
 		syncCommand,
+		environment,
 	});
-	let tsCode = printTsNodeSegments({ segments: runtimeSegments, context });
-	tsCode = insertBlankLineAfterDoubleSlashBanner(tsCode);
-	tsCode = finalizeGeneratedSourceWithTrailingNewline(tsCode);
-	writeTextArtifact({ filePath: buildIndexTsPath, content: tsCode });
+	let runtimeTsCode = printTsNodeSegments({ segments: runtimeSegments, context });
+	runtimeTsCode = insertBlankLineAfterDoubleSlashBanner(runtimeTsCode);
+	runtimeTsCode = finalizeGeneratedSourceWithTrailingNewline(runtimeTsCode);
+	const code =
+		environment === "javascript"
+			? transpileTsToJs({
+					typescriptCode: runtimeTsCode,
+					module: TS_EMIT_OPTIONS_DEFAULT.module,
+					target: TS_EMIT_OPTIONS_DEFAULT.target,
+					esModuleInterop: TS_EMIT_INTEROP.esModuleInterop,
+					allowSyntheticDefaultImports:
+						TS_EMIT_INTEROP.allowSyntheticDefaultImports,
+				})
+			: runtimeTsCode;
+	writeTextArtifact({ filePath: buildIndexPath, content: code });
 
 	const declarationSegments = buildOrmIndexDeclarationStatementSegments({
 		databases,
@@ -694,7 +733,7 @@ export function emitOrmIndexArtifacts(args: {
 		fs.unlinkSync(buildIndexDtsMapPath);
 	}
 
-	return { tsCode, dtsCode };
+	return { code, dtsCode };
 }
 
 /**
@@ -705,6 +744,7 @@ export function emitOrmIndexArtifacts(args: {
 export function updateSourceIndexFile(
 	databasesMetadata: CachedEntityMetadata[],
 	agentsMetadata: CachedEntityMetadata[],
+	environment: CodegenEnvironment,
 ): void {
 	if (!fs.existsSync(AST_FS_PATHS.CODEGEN_ROOT_DIR)) {
 		fs.mkdirSync(AST_FS_PATHS.CODEGEN_ROOT_DIR, { recursive: true });
@@ -713,6 +753,7 @@ export function updateSourceIndexFile(
 	emitOrmIndexBuildArtifacts({
 		databases: databasesMetadata.map((m) => ({ name: m.name })),
 		agents: agentsMetadata.map((m) => ({ name: m.name })),
+		environment,
 	});
 }
 
@@ -722,16 +763,22 @@ export function updateSourceIndexFile(
 function emitOrmIndexBuildArtifacts(args: {
 	databases: OrmEntityMetadata[];
 	agents: OrmEntityMetadata[];
+	environment: CodegenEnvironment;
 	context?: TsEmitContext;
-}): { tsCode: string; dtsCode: string } {
-	const { databases, agents, context } = args;
+}): { code: string; dtsCode: string } {
+	const { databases, agents, environment, context } = args;
+	const buildIndexPath =
+		environment === "typescript"
+			? AST_FS_PATHS.buildIndexTs
+			: AST_FS_PATHS.buildIndexJs;
 	return emitOrmIndexArtifacts({
 		databases,
 		agents,
-		buildIndexTsPath: AST_FS_PATHS.buildIndexTs,
+		buildIndexPath,
 		buildIndexDtsPath: AST_FS_PATHS.buildIndexDts,
 		buildIndexDtsMapPath: AST_FS_PATHS.buildIndexDtsMap,
 		syncCommand: AST_RUNTIME_CONSTANTS.CLI_GENERATE_COMMAND,
+		environment,
 		context,
 	});
 }

--- a/src/ast/shared/emit/orm-index-emitter.ts
+++ b/src/ast/shared/emit/orm-index-emitter.ts
@@ -13,10 +13,8 @@ import {
 	insertBlankLineAfterDoubleSlashBanner,
 	printTsNodeSegments,
 	type TsEmitContext,
-	transpileTsToJs,
 	writeTextArtifact,
 } from "./ts-emit-core";
-import { TS_EMIT_INTEROP, TS_EMIT_OPTIONS_DEFAULT } from "./ts-emit-options";
 
 /**
  * Minimal metadata needed to wire generated databases/agents into NotionORM.
@@ -654,17 +652,15 @@ export function emitOrmIndexArtifacts(args: {
 	databases: OrmEntityMetadata[];
 	agents: OrmEntityMetadata[];
 	buildIndexTsPath: string;
-	buildIndexJsPath: string;
 	buildIndexDtsPath: string;
 	buildIndexDtsMapPath?: string;
 	syncCommand: string;
 	context?: TsEmitContext;
-}): { tsCode: string; jsCode: string; dtsCode: string } {
+}): { tsCode: string; dtsCode: string } {
 	const {
 		databases,
 		agents,
 		buildIndexTsPath,
-		buildIndexJsPath,
 		buildIndexDtsPath,
 		buildIndexDtsMapPath,
 		syncCommand,
@@ -678,15 +674,7 @@ export function emitOrmIndexArtifacts(args: {
 	let tsCode = printTsNodeSegments({ segments: runtimeSegments, context });
 	tsCode = insertBlankLineAfterDoubleSlashBanner(tsCode);
 	tsCode = finalizeGeneratedSourceWithTrailingNewline(tsCode);
-	const jsCode = transpileTsToJs({
-		typescriptCode: tsCode,
-		module: TS_EMIT_OPTIONS_DEFAULT.module,
-		target: TS_EMIT_OPTIONS_DEFAULT.target,
-		esModuleInterop: TS_EMIT_INTEROP.esModuleInterop,
-		allowSyntheticDefaultImports: TS_EMIT_INTEROP.allowSyntheticDefaultImports,
-	});
 	writeTextArtifact({ filePath: buildIndexTsPath, content: tsCode });
-	writeTextArtifact({ filePath: buildIndexJsPath, content: jsCode });
 
 	const declarationSegments = buildOrmIndexDeclarationStatementSegments({
 		databases,
@@ -706,7 +694,7 @@ export function emitOrmIndexArtifacts(args: {
 		fs.unlinkSync(buildIndexDtsMapPath);
 	}
 
-	return { tsCode, jsCode, dtsCode };
+	return { tsCode, dtsCode };
 }
 
 /**
@@ -735,13 +723,12 @@ function emitOrmIndexBuildArtifacts(args: {
 	databases: OrmEntityMetadata[];
 	agents: OrmEntityMetadata[];
 	context?: TsEmitContext;
-}): { tsCode: string; jsCode: string; dtsCode: string } {
+}): { tsCode: string; dtsCode: string } {
 	const { databases, agents, context } = args;
 	return emitOrmIndexArtifacts({
 		databases,
 		agents,
 		buildIndexTsPath: AST_FS_PATHS.buildIndexTs,
-		buildIndexJsPath: AST_FS_PATHS.buildIndexJs,
 		buildIndexDtsPath: AST_FS_PATHS.buildIndexDts,
 		buildIndexDtsMapPath: AST_FS_PATHS.buildIndexDtsMap,
 		syncCommand: AST_RUNTIME_CONSTANTS.CLI_GENERATE_COMMAND,

--- a/src/ast/shared/emit/orm-index-emitter.ts
+++ b/src/ast/shared/emit/orm-index-emitter.ts
@@ -6,10 +6,10 @@ import {
 	AST_FS_PATHS,
 	AST_IMPORT_PATHS,
 	AST_RUNTIME_CONSTANTS,
+	codegenIndexSourcePath,
 } from "../constants";
 import {
 	type CodegenEnvironment,
-	getCodegenArtifactExtension,
 	getCodegenImportExtension,
 } from "../codegen-environment";
 import {
@@ -767,10 +767,10 @@ function emitOrmIndexBuildArtifacts(args: {
 	context?: TsEmitContext;
 }): { code: string; dtsCode: string } {
 	const { databases, agents, environment, context } = args;
-	const buildIndexPath =
-		environment === "typescript"
-			? AST_FS_PATHS.buildIndexTs
-			: AST_FS_PATHS.buildIndexJs;
+	const buildIndexPath = codegenIndexSourcePath({
+		scope: "codegenRoot",
+		environment,
+	});
 	return emitOrmIndexArtifacts({
 		databases,
 		agents,

--- a/src/ast/shared/emit/registry-emitter.ts
+++ b/src/ast/shared/emit/registry-emitter.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
 import type { CodegenEnvironment } from "../codegen-environment";
-import { emitJsArtifacts, emitTsArtifacts, type TsEmitContext } from "./ts-emit-core";
+import { emitArtifactsForEnvironment, type TsEmitContext } from "./ts-emit-core";
 import { TS_EMIT_OPTIONS_DEFAULT } from "./ts-emit-options";
 
 /**
@@ -69,31 +69,24 @@ export function buildRegistryModuleAst(args: {
 
 /**
  * Emits the registry module in the format appropriate for the consumer project.
+ * `outputPath` should already be extension-correct for `environment`
+ * (use `codegenIndexSourcePath` to build it).
  */
 export function emitRegistryModuleArtifacts(args: {
 	registryName: string;
 	entries: RegistryEntry[];
-	tsPath: string;
-	jsPath: string;
+	outputPath: string;
 	environment: CodegenEnvironment;
 	context?: TsEmitContext;
 }): { sourceCode: string } {
-	const { registryName, entries, tsPath, jsPath, environment, context } = args;
+	const { registryName, entries, outputPath, environment, context } = args;
 	const nodes = buildRegistryModuleAst({ registryName, entries });
-	if (environment === "typescript") {
-		const { tsCode } = emitTsArtifacts({
-			nodes,
-			tsPath,
-			context,
-		});
-		return { sourceCode: tsCode };
-	}
-	const { jsCode } = emitJsArtifacts({
+	return emitArtifactsForEnvironment({
 		nodes,
-		jsPath,
+		outputPath,
+		environment,
 		context,
 		module: TS_EMIT_OPTIONS_DEFAULT.module,
 		target: TS_EMIT_OPTIONS_DEFAULT.target,
 	});
-	return { sourceCode: jsCode };
 }

--- a/src/ast/shared/emit/registry-emitter.ts
+++ b/src/ast/shared/emit/registry-emitter.ts
@@ -1,5 +1,7 @@
 import * as ts from "typescript";
-import { emitTsArtifacts, type TsEmitContext } from "./ts-emit-core";
+import type { CodegenEnvironment } from "../codegen-environment";
+import { emitJsArtifacts, emitTsArtifacts, type TsEmitContext } from "./ts-emit-core";
+import { TS_EMIT_OPTIONS_DEFAULT } from "./ts-emit-options";
 
 /**
  * One exported item inside a generated registry module
@@ -66,19 +68,32 @@ export function buildRegistryModuleAst(args: {
 }
 
 /**
- * Emits the TypeScript registry module consumed by app-level builds.
+ * Emits the registry module in the format appropriate for the consumer project.
  */
 export function emitRegistryModuleArtifacts(args: {
 	registryName: string;
 	entries: RegistryEntry[];
 	tsPath: string;
+	jsPath: string;
+	environment: CodegenEnvironment;
 	context?: TsEmitContext;
-}): { tsCode: string } {
-	const { registryName, entries, tsPath, context } = args;
+}): { sourceCode: string } {
+	const { registryName, entries, tsPath, jsPath, environment, context } = args;
 	const nodes = buildRegistryModuleAst({ registryName, entries });
-	return emitTsArtifacts({
+	if (environment === "typescript") {
+		const { tsCode } = emitTsArtifacts({
+			nodes,
+			tsPath,
+			context,
+		});
+		return { sourceCode: tsCode };
+	}
+	const { jsCode } = emitJsArtifacts({
 		nodes,
-		tsPath,
+		jsPath,
 		context,
+		module: TS_EMIT_OPTIONS_DEFAULT.module,
+		target: TS_EMIT_OPTIONS_DEFAULT.target,
 	});
+	return { sourceCode: jsCode };
 }

--- a/src/ast/shared/emit/registry-emitter.ts
+++ b/src/ast/shared/emit/registry-emitter.ts
@@ -1,6 +1,5 @@
 import * as ts from "typescript";
-import { emitTsAndJsArtifacts, type TsEmitContext } from "./ts-emit-core";
-import { TS_EMIT_OPTIONS_DEFAULT } from "./ts-emit-options";
+import { emitTsArtifacts, type TsEmitContext } from "./ts-emit-core";
 
 /**
  * One exported item inside a generated registry module
@@ -67,24 +66,19 @@ export function buildRegistryModuleAst(args: {
 }
 
 /**
- * Emits TypeScript + JavaScript artifacts for a registry module.
- * This is used by both database and agent barrel generation.
+ * Emits the TypeScript registry module consumed by app-level builds.
  */
 export function emitRegistryModuleArtifacts(args: {
 	registryName: string;
 	entries: RegistryEntry[];
 	tsPath: string;
-	jsPath: string;
 	context?: TsEmitContext;
-}): { tsCode: string; jsCode: string } {
-	const { registryName, entries, tsPath, jsPath, context } = args;
+}): { tsCode: string } {
+	const { registryName, entries, tsPath, context } = args;
 	const nodes = buildRegistryModuleAst({ registryName, entries });
-	return emitTsAndJsArtifacts({
+	return emitTsArtifacts({
 		nodes,
 		tsPath,
-		jsPath,
 		context,
-		module: TS_EMIT_OPTIONS_DEFAULT.module,
-		target: TS_EMIT_OPTIONS_DEFAULT.target,
 	});
 }

--- a/src/ast/shared/emit/ts-emit-core.ts
+++ b/src/ast/shared/emit/ts-emit-core.ts
@@ -136,7 +136,7 @@ export function writeTextArtifact(args: {
 /**
  * End-to-end helper used by AST generators that only emit TypeScript source.
  */
-export function emitTsArtifacts(args: {
+function emitTsArtifacts(args: {
 	nodes: readonly ts.Statement[];
 	outputPath: string;
 	context?: TsEmitContext;
@@ -155,7 +155,7 @@ export function emitTsArtifacts(args: {
 /**
  * End-to-end helper used by AST generators that emit runtime JavaScript files.
  */
-export function emitJsArtifacts(args: {
+function emitJsArtifacts(args: {
 	nodes: readonly ts.Statement[];
 	outputPath: string;
 	context?: TsEmitContext;

--- a/src/ast/shared/emit/ts-emit-core.ts
+++ b/src/ast/shared/emit/ts-emit-core.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import * as ts from "typescript";
+import type { CodegenEnvironment } from "../codegen-environment";
 import { TS_EMIT_SOURCE_TARGET } from "./ts-emit-options";
 
 /**
@@ -149,4 +150,93 @@ export function emitTsArtifacts(args: {
 	});
 	writeTextArtifact({ filePath: tsPath, content: tsCode });
 	return { tsCode };
+}
+
+/**
+ * End-to-end helper used by AST generators that emit runtime JavaScript files.
+ */
+export function emitJsArtifacts(args: {
+	nodes: readonly ts.Statement[];
+	jsPath: string;
+	context?: TsEmitContext;
+	listFormat?: ts.ListFormat;
+	module?: ts.ModuleKind;
+	target?: ts.ScriptTarget;
+	esModuleInterop?: boolean;
+	allowSyntheticDefaultImports?: boolean;
+}): { jsCode: string } {
+	const {
+		nodes,
+		jsPath,
+		context,
+		listFormat,
+		module,
+		target,
+		esModuleInterop,
+		allowSyntheticDefaultImports,
+	} = args;
+	const typescriptCode = printTsNodes({
+		nodes,
+		context,
+		listFormat,
+	});
+	const jsCode = transpileTsToJs({
+		typescriptCode,
+		module,
+		target,
+		esModuleInterop,
+		allowSyntheticDefaultImports,
+	});
+	writeTextArtifact({ filePath: jsPath, content: jsCode });
+	return { jsCode };
+}
+
+/**
+ * End-to-end helper used by AST generators that emit either TS or JS based on
+ * the consumer project's codegen environment.
+ */
+export function emitArtifactsForEnvironment(args: {
+	nodes: readonly ts.Statement[];
+	tsPath: string;
+	jsPath: string;
+	environment: CodegenEnvironment;
+	context?: TsEmitContext;
+	listFormat?: ts.ListFormat;
+	module?: ts.ModuleKind;
+	target?: ts.ScriptTarget;
+	esModuleInterop?: boolean;
+	allowSyntheticDefaultImports?: boolean;
+}): { sourceCode: string } {
+	const {
+		nodes,
+		tsPath,
+		jsPath,
+		environment,
+		context,
+		listFormat,
+		module,
+		target,
+		esModuleInterop,
+		allowSyntheticDefaultImports,
+	} = args;
+	if (environment === "typescript") {
+		const { tsCode } = emitTsArtifacts({
+			nodes,
+			tsPath,
+			context,
+			listFormat,
+		});
+		return { sourceCode: tsCode };
+	}
+	const { jsCode } = emitJsArtifacts({
+		nodes,
+		jsPath,
+		context,
+		listFormat,
+		module,
+		target,
+		esModuleInterop,
+		allowSyntheticDefaultImports,
+	});
+	return { sourceCode: jsCode };
 }

--- a/src/ast/shared/emit/ts-emit-core.ts
+++ b/src/ast/shared/emit/ts-emit-core.ts
@@ -138,17 +138,17 @@ export function writeTextArtifact(args: {
  */
 export function emitTsArtifacts(args: {
 	nodes: readonly ts.Statement[];
-	tsPath: string;
+	outputPath: string;
 	context?: TsEmitContext;
 	listFormat?: ts.ListFormat;
 }): { tsCode: string } {
-	const { nodes, tsPath, context, listFormat } = args;
+	const { nodes, outputPath, context, listFormat } = args;
 	const tsCode = printTsNodes({
 		nodes,
 		context,
 		listFormat,
 	});
-	writeTextArtifact({ filePath: tsPath, content: tsCode });
+	writeTextArtifact({ filePath: outputPath, content: tsCode });
 	return { tsCode };
 }
 
@@ -157,7 +157,7 @@ export function emitTsArtifacts(args: {
  */
 export function emitJsArtifacts(args: {
 	nodes: readonly ts.Statement[];
-	jsPath: string;
+	outputPath: string;
 	context?: TsEmitContext;
 	listFormat?: ts.ListFormat;
 	module?: ts.ModuleKind;
@@ -167,7 +167,7 @@ export function emitJsArtifacts(args: {
 }): { jsCode: string } {
 	const {
 		nodes,
-		jsPath,
+		outputPath,
 		context,
 		listFormat,
 		module,
@@ -187,18 +187,19 @@ export function emitJsArtifacts(args: {
 		esModuleInterop,
 		allowSyntheticDefaultImports,
 	});
-	writeTextArtifact({ filePath: jsPath, content: jsCode });
+	writeTextArtifact({ filePath: outputPath, content: jsCode });
 	return { jsCode };
 }
 
 /**
  * End-to-end helper used by AST generators that emit either TS or JS based on
- * the consumer project's codegen environment.
+ * the consumer project's codegen environment. Callers pass a single
+ * `outputPath` already resolved to the correct extension (see
+ * `codegenIndexSourcePath`); this keeps TS/JS filename selection in one place.
  */
 export function emitArtifactsForEnvironment(args: {
 	nodes: readonly ts.Statement[];
-	tsPath: string;
-	jsPath: string;
+	outputPath: string;
 	environment: CodegenEnvironment;
 	context?: TsEmitContext;
 	listFormat?: ts.ListFormat;
@@ -209,8 +210,7 @@ export function emitArtifactsForEnvironment(args: {
 }): { sourceCode: string } {
 	const {
 		nodes,
-		tsPath,
-		jsPath,
+		outputPath,
 		environment,
 		context,
 		listFormat,
@@ -222,7 +222,7 @@ export function emitArtifactsForEnvironment(args: {
 	if (environment === "typescript") {
 		const { tsCode } = emitTsArtifacts({
 			nodes,
-			tsPath,
+			outputPath,
 			context,
 			listFormat,
 		});
@@ -230,7 +230,7 @@ export function emitArtifactsForEnvironment(args: {
 	}
 	const { jsCode } = emitJsArtifacts({
 		nodes,
-		jsPath,
+		outputPath,
 		context,
 		listFormat,
 		module,

--- a/src/ast/shared/emit/ts-emit-core.ts
+++ b/src/ast/shared/emit/ts-emit-core.ts
@@ -1,10 +1,7 @@
 import fs from "fs";
 import path from "path";
 import * as ts from "typescript";
-import {
-	TS_EMIT_OPTIONS_DEFAULT,
-	TS_EMIT_SOURCE_TARGET,
-} from "./ts-emit-options";
+import { TS_EMIT_SOURCE_TARGET } from "./ts-emit-options";
 
 /**
  * Shared emit context used by all AST-based codegen modules.
@@ -100,8 +97,8 @@ export function transpileTsToJs(args: {
 }): string {
 	const {
 		typescriptCode,
-		module = TS_EMIT_OPTIONS_DEFAULT.module,
-		target = TS_EMIT_OPTIONS_DEFAULT.target,
+		module = ts.ModuleKind.ES2020,
+		target = ts.ScriptTarget.ES2020,
 		esModuleInterop,
 		allowSyntheticDefaultImports,
 	} = args;
@@ -136,44 +133,20 @@ export function writeTextArtifact(args: {
 }
 
 /**
- * End-to-end helper used by AST generators:
- * print TS -> transpile JS -> write both files.
+ * End-to-end helper used by AST generators that only emit TypeScript source.
  */
-export function emitTsAndJsArtifacts(args: {
+export function emitTsArtifacts(args: {
 	nodes: readonly ts.Statement[];
 	tsPath: string;
-	jsPath: string;
 	context?: TsEmitContext;
 	listFormat?: ts.ListFormat;
-	module?: ts.ModuleKind;
-	target?: ts.ScriptTarget;
-	esModuleInterop?: boolean;
-	allowSyntheticDefaultImports?: boolean;
-}): { tsCode: string; jsCode: string } {
-	const {
-		nodes,
-		tsPath,
-		jsPath,
-		context,
-		listFormat,
-		module,
-		target,
-		esModuleInterop,
-		allowSyntheticDefaultImports,
-	} = args;
+}): { tsCode: string } {
+	const { nodes, tsPath, context, listFormat } = args;
 	const tsCode = printTsNodes({
 		nodes,
 		context,
 		listFormat,
 	});
-	const jsCode = transpileTsToJs({
-		typescriptCode: tsCode,
-		module,
-		target,
-		esModuleInterop,
-		allowSyntheticDefaultImports,
-	});
 	writeTextArtifact({ filePath: tsPath, content: tsCode });
-	writeTextArtifact({ filePath: jsPath, content: jsCode });
-	return { tsCode, jsCode };
+	return { tsCode };
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,7 +1,7 @@
 /**
  * Base exports for @haustle/notion-orm
  * This file contains the stable base classes that generated code extends.
- * The main index.ts is generated and re-exports from here plus adds generated types.
+ * Consumer-local `notion/index.ts` is generated and extends the classes exported here.
  */
 
 import type { NotionORMConfig } from "./config/resolveNotionAuth";
@@ -63,7 +63,7 @@ export {
 	toNotionPageId,
 	toNotionUserId,
 } from "./client/database/types";
-export type { NotionConfigType } from "./config/helpers";
+export type { NotionConfigType } from "./config/types";
 export type { NotionORMConfig } from "./config/resolveNotionAuth";
 export { resolveNotionAuth } from "./config/resolveNotionAuth";
 export type { Simplify } from "./typeUtils";

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -5,9 +5,13 @@ import {
 	type ConfigListItem,
 	type ConfigListKey,
 	type ConfigListUpdateStrategy,
-	renderConfigTemplateModule,
 	updateConfigListInConfigModule,
 } from "../ast/shared/emit/config-emitter";
+export {
+	createConfigTemplate,
+	shouldUseTypeScript,
+	showSetupInstructions,
+} from "../config/init";
 import { toDashedNotionId, toUndashedNotionId } from "../helpers";
 
 const CONFIG_FILE_FORMATTERS = [
@@ -81,57 +85,6 @@ function formatConfigFileIfPossible(args: { configPath: string }): void {
 			"⚠️  Updated config but could not auto-format it with local prettier/biome.",
 		);
 	}
-}
-
-/** Heuristic for `notion init`: TS projects get a TS config template by default. */
-export function shouldUseTypeScript(): boolean {
-	const cwd = process.cwd();
-	const tsConfigCandidates = [
-		"tsconfig.json",
-		"tsconfig.app.json",
-		"tsconfig.base.json",
-		"tsconfig.build.json",
-	];
-
-	for (const candidate of tsConfigCandidates) {
-		if (fs.existsSync(path.join(cwd, candidate))) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-/** Renders the starter config template and guarantees a trailing newline. */
-export function createConfigTemplate(isTS: boolean): string {
-	const renderedTemplate = renderConfigTemplateModule({ isTS });
-	return renderedTemplate.endsWith("\n")
-		? renderedTemplate
-		: `${renderedTemplate}\n`;
-}
-
-/** Prints setup guidance together with copy-pastable example configs. */
-export function showSetupInstructions(): void {
-	console.log("\n📚 Setup Instructions:");
-	console.log(
-		"1. Run: notion init [--ts|--js] (defaults to TypeScript when tsconfig.json is present)",
-	);
-	console.log("2. Add your Notion integration token and database IDs");
-	console.log("3. Run: notion sync (generates database types)");
-	console.log(
-		"4. (Optional) Run: notion setup-agents-sdk (installs the paid Agents SDK, then re-run notion sync)",
-	);
-
-	console.log("\n📝 Example JavaScript config (notion.config.js):");
-	console.log(`\n${createConfigTemplate(false).trimEnd()}\n`);
-
-	console.log("📝 Example TypeScript config (notion.config.ts):");
-	console.log(`\n${createConfigTemplate(true).trimEnd()}\n`);
-
-	console.log("\n🔗 Need help getting your integration token?");
-	console.log(
-		"   Visit: https://developers.notion.com/docs/create-a-notion-integration",
-	);
 }
 
 export function validateAndGetUndashedNotionId(id: string): string | undefined {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,10 @@ import {
 	initializeNotionConfigFile,
 	validateConfig,
 } from "../config/helpers";
+import {
+	NOTION_CONFIG_BASENAME,
+	NOTION_CONFIG_EXTENSION_LABELS,
+} from "../config/notion-config-filenames";
 import { resolveCodegenEnvironment } from "../ast/shared/codegen-environment";
 import {
 	createAgentTypes,
@@ -247,7 +251,7 @@ async function runSync(): Promise<void> {
 		const configFile = findConfigFile();
 		if (configFile) {
 			const configFileName =
-				configFile.path.split(/[\\/]/).pop() ?? "notion.config";
+				configFile.path.split(/[\\/]/).pop() ?? NOTION_CONFIG_BASENAME;
 			console.log(
 				`📝 ${configFileName} contains the full list of connected databases and agents.`,
 			);
@@ -313,14 +317,14 @@ async function runAdd(input: string): Promise<void> {
 
 	if (!configFile) {
 		console.error(
-			"❌ No config file found. Could not find a notion.config.(ts|js) in project root",
+			`❌ No config file found. Could not find notion.config.(${NOTION_CONFIG_EXTENSION_LABELS}) in project root`,
 		);
 		console.error("Run 'notion init' to create a config file first");
 		process.exit(1);
 	}
 
 	console.log(
-		`🔍 Found config: notion.config.${configFile.isTS ? "ts" : "js"}`,
+		`🔍 Found config: ${configFile.path.split(/[\\/]/).pop() ?? NOTION_CONFIG_BASENAME}`,
 	);
 
 	clearConfigCache();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,13 +1,11 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
+// Node shebang: `notion` bin must run under Node (see `engines.node`) so `npx notion` works without Bun.
 
-import * as readline from "node:readline";
 import fs from "fs";
 import { Client } from "@notionhq/client";
-import {
-	findConfigFile,
-	initializeNotionConfigFile,
-	validateConfig,
-} from "../config/helpers";
+import { initializeNotionConfigFile, validateConfig } from "../config/helpers";
+import { findConfigFile } from "../config/findConfigFile";
+import { showSetupInstructions } from "../config/init";
 import {
 	NOTION_CONFIG_BASENAME,
 	NOTION_CONFIG_EXTENSION_LABELS,
@@ -23,143 +21,52 @@ import {
 	readAgentMetadataFromDisk,
 	readDatabaseMetadata,
 } from "../ast/shared/cached-metadata";
-import { AST_FS_PATHS, AST_RUNTIME_CONSTANTS } from "../ast/shared/constants";
+import { AST_FS_PATHS } from "../ast/shared/constants";
 import { updateSourceIndexFile } from "../ast/shared/emit/orm-index-emitter";
 import { clearConfigCache, loadConfig } from "../config/loadConfig";
 import { toDashedNotionId, toUndashedNotionId } from "../helpers";
+import { PACKAGE_RUNTIME_CONSTANTS } from "../runtime-constants";
 import {
 	isHelpCommand,
-	showSetupInstructions,
 	validateAndGetUndashedNotionId,
 	writeConfigFileWithAST,
 } from "./helpers";
-
-type ProgressRowState = "running" | "done" | "unavailable";
-type ProgressRowKey = "agents" | "databases";
-type ProgressRow = {
-	label: string;
-	completed: number;
-	total: number;
-	state: ProgressRowState;
-};
-
-/**
- * Small terminal renderer that keeps sync progress readable without interleaving
- * the agent and database generation logs.
- */
-class SyncProgressRenderer {
-	private readonly spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
-	private spinnerIndex = 0;
-	private interval: ReturnType<typeof setInterval> | undefined;
-	private hasRendered = false;
-	private readonly rows: Record<ProgressRowKey, ProgressRow> = {
-		agents: {
-			label: "Agents",
-			completed: 0,
-			total: 0,
-			state: "running",
-		},
-		databases: {
-			label: "Databases",
-			completed: 0,
-			total: 0,
-			state: "running",
-		},
-	};
-
-	constructor(private readonly isTTY: boolean) {}
-
-	start(): void {
-		const header = this.isTTY
-			? "\x1b[1m📐 Updating static types\x1b[0m"
-			: "📐 Updating static types";
-		console.log(header);
-		if (this.isTTY) {
-			this.render();
-			this.interval = setInterval(() => {
-				this.spinnerIndex = (this.spinnerIndex + 1) % this.spinnerFrames.length;
-				this.render();
-			}, 90);
-		} else {
-			console.log(this.formatRow(this.rows.agents));
-			console.log(this.formatRow(this.rows.databases));
-		}
-	}
-
-	updateProgress(key: ProgressRowKey, completed: number, total: number): void {
-		const row = this.rows[key];
-		row.completed = completed;
-		row.total = total;
-		if (row.state !== "done") {
-			if (total === 0) {
-				row.state = "unavailable";
-			} else if (completed >= total) {
-				row.state = "done";
-			} else {
-				row.state = "running";
-			}
-		}
-		if (this.isTTY) {
-			this.render();
-		}
-	}
-
-	complete(key: ProgressRowKey): void {
-		const row = this.rows[key];
-		row.state = row.total === 0 ? "unavailable" : "done";
-		if (this.isTTY) {
-			this.render();
-		}
-	}
-
-	stop(): void {
-		if (this.interval) {
-			clearInterval(this.interval);
-			this.interval = undefined;
-		}
-		if (this.isTTY) {
-			this.render();
-			process.stdout.write("\n");
-		} else {
-			console.log(this.formatRow(this.rows.agents));
-			console.log(this.formatRow(this.rows.databases));
-		}
-	}
-
-	private formatRow(row: ProgressRow): string {
-		if (row.state === "unavailable") {
-			return `${row.label}: unavailable`;
-		}
-		const countLabel = `[${row.completed}/${row.total}]`;
-		const marker =
-			row.state === "done"
-				? "✔"
-				: this.isTTY
-					? this.spinnerFrames[this.spinnerIndex]
-					: "...";
-		return `${row.label}: ${marker} ${countLabel}`;
-	}
-
-	private render(): void {
-		const lines = [
-			this.formatRow(this.rows.agents),
-			this.formatRow(this.rows.databases),
-		];
-		if (this.hasRendered) {
-			readline.moveCursor(process.stdout, 0, -lines.length);
-		}
-		for (const line of lines) {
-			readline.clearLine(process.stdout, 0);
-			process.stdout.write(`${line}\n`);
-		}
-		this.hasRendered = true;
-	}
-}
+import { SyncProgressRenderer } from "./sync-progress-renderer";
 
 function exitWithError(message: string, error: unknown): never {
 	console.error(message);
 	console.error(error);
 	process.exit(1);
+}
+
+/** Short example of wiring the generated `notion` entry (printed after sync). */
+function logNotionEntrypointExample(args: {
+	databaseKey: string | undefined;
+	agentKey: string | undefined;
+	agentsSkipped: boolean;
+}): void {
+	const { databaseKey, agentKey, agentsSkipped } = args;
+	const body: string[] = [
+		'import { NotionORM } from "./notion";',
+		"const notion = new NotionORM({ auth: process.env.NOTION_KEY! });",
+	];
+	if (databaseKey) {
+		body.push(`notion.databases.${databaseKey};`);
+	} else {
+		body.push("// notion.databases.* — add a database in config, then sync");
+	}
+	if (agentsSkipped) {
+		body.push(
+			"// notion.agents.* — `notion setup-agents-sdk` then `notion sync`",
+		);
+	} else if (agentKey) {
+		body.push(`notion.agents.${agentKey};`);
+	} else {
+		body.push("// notion.agents.* — sync when your workspace has agents");
+	}
+	for (const line of body) {
+		console.log(line);
+	}
 }
 
 /** Runs agent and database generation in parallel, then refreshes the root index once. */
@@ -210,17 +117,25 @@ async function runSync(): Promise<void> {
 		);
 
 		const { databaseNames, databaseKeys } = databasesResult;
+		const firstDatabaseKey = databaseKeys[0];
+		const firstAgentKey = agentsResult.agentKeys[0];
+
+		console.log("");
+		logNotionEntrypointExample({
+			databaseKey: firstDatabaseKey,
+			agentKey: firstAgentKey,
+			agentsSkipped: agentsResult.skipped,
+		});
+		console.log("");
+
 		if (databaseNames.length === 0) {
-			console.log("📂 Databases: none in config (nothing generated under notion/databases).");
-		} else if (databaseNames.length === 1) {
 			console.log(
-				`📂 Databases (1): ${databaseNames[0]} → notion.databases.${databaseKeys[0]}`,
+				"📂 Databases: none in config (nothing generated under notion/databases).",
 			);
 		} else {
 			const lines = databaseNames
 				.map(
-					(title, i) =>
-						`   • ${title} → notion.databases.${databaseKeys[i]}`,
+					(title, i) => `   • ${title} → notion.databases.${databaseKeys[i]}`,
 				)
 				.join("\n");
 			console.log(`📂 Databases (${databaseNames.length}):\n${lines}`);
@@ -232,8 +147,6 @@ async function runSync(): Promise<void> {
 			);
 		} else if (agentsResult.agentNames.length === 0) {
 			console.log("🤖 Agents: none returned for this integration.");
-		} else if (agentsResult.agentNames.length === 1) {
-			console.log(`🤖 Agents (1): ${agentsResult.agentNames[0]}`);
 		} else {
 			const lines = agentsResult.agentNames.map((n) => `   • ${n}`).join("\n");
 			console.log(`🤖 Agents (${agentsResult.agentNames.length}):\n${lines}`);
@@ -277,7 +190,7 @@ async function fetchDatabaseName(args: {
 	try {
 		const client = new Client({
 			auth: args.auth,
-			notionVersion: AST_RUNTIME_CONSTANTS.NOTION_API_VERSION,
+			notionVersion: PACKAGE_RUNTIME_CONSTANTS.NOTION_API_VERSION,
 		});
 		const databaseObject = await client.dataSources.retrieve({
 			data_source_id: args.dataSourceId,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import {
 	initializeNotionConfigFile,
 	validateConfig,
 } from "../config/helpers";
+import { resolveCodegenEnvironment } from "../ast/shared/codegen-environment";
 import {
 	createAgentTypes,
 	type CreateAgentTypesResult,
@@ -198,7 +199,11 @@ async function runSync(): Promise<void> {
 		const agentsMetadata = agentsResult.skipped
 			? []
 			: readAgentMetadataFromDisk();
-		updateSourceIndexFile(readDatabaseMetadata(), agentsMetadata);
+		updateSourceIndexFile(
+			readDatabaseMetadata(),
+			agentsMetadata,
+			resolveCodegenEnvironment({ configRuntime: findConfigFile() }),
+		);
 
 		const { databaseNames, databaseKeys } = databasesResult;
 		if (databaseNames.length === 0) {

--- a/src/cli/sync-progress-renderer.ts
+++ b/src/cli/sync-progress-renderer.ts
@@ -1,0 +1,128 @@
+import * as readline from "node:readline";
+
+type ProgressRowState = "running" | "done" | "unavailable";
+type ProgressRowKey = "agents" | "databases";
+type ProgressRow = {
+	label: string;
+	completed: number;
+	total: number;
+	state: ProgressRowState;
+};
+
+/**
+ * Small terminal renderer that keeps sync progress readable without interleaving
+ * the agent and database generation logs. On TTY, redraws two rows (agents +
+ * databases) with one shared spinner.
+ */
+export class SyncProgressRenderer {
+	private readonly spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
+	private spinnerIndex = 0;
+	private interval: ReturnType<typeof setInterval> | undefined;
+	private hasRendered = false;
+	private readonly rows: Record<ProgressRowKey, ProgressRow> = {
+		agents: {
+			label: "Agents",
+			completed: 0,
+			total: 0,
+			state: "running",
+		},
+		databases: {
+			label: "Databases",
+			completed: 0,
+			total: 0,
+			state: "running",
+		},
+	};
+
+	constructor(private readonly isTTY: boolean) {}
+
+	start(): void {
+		const header = this.isTTY
+			? "\x1b[1m📐 Updating static types\x1b[0m"
+			: "📐 Updating static types";
+		console.log(header);
+		if (this.isTTY) {
+			this.render();
+			this.interval = setInterval(() => {
+				this.spinnerIndex = (this.spinnerIndex + 1) % this.spinnerFrames.length;
+				this.render();
+			}, 90);
+		} else {
+			console.log(this.formatCombined());
+		}
+	}
+
+	updateProgress(key: ProgressRowKey, completed: number, total: number): void {
+		const row = this.rows[key];
+		row.completed = completed;
+		row.total = total;
+		if (row.state !== "done") {
+			if (total === 0) {
+				row.state = "unavailable";
+			} else if (completed >= total) {
+				row.state = "done";
+			} else {
+				row.state = "running";
+			}
+		}
+		if (this.isTTY) {
+			this.render();
+		}
+	}
+
+	complete(key: ProgressRowKey): void {
+		const row = this.rows[key];
+		row.state = row.total === 0 ? "unavailable" : "done";
+		if (this.isTTY) {
+			this.render();
+		}
+	}
+
+	stop(): void {
+		if (this.interval) {
+			clearInterval(this.interval);
+			this.interval = undefined;
+		}
+		if (this.isTTY) {
+			this.render();
+			process.stdout.write("\n");
+		} else {
+			console.log(this.formatCombined());
+		}
+	}
+
+	private isRowTerminal(row: ProgressRow): boolean {
+		return row.state === "done" || row.state === "unavailable";
+	}
+
+	private formatSegmentBody(row: ProgressRow): string {
+		if (row.state === "unavailable") {
+			return "unavailable";
+		}
+		return `[${row.completed}/${row.total}]`;
+	}
+
+	private formatCombined(): string {
+		const d = this.rows.databases;
+		const a = this.rows.agents;
+		const left = `Databases: ${this.formatSegmentBody(d)}`;
+		const right = `Agents: ${this.formatSegmentBody(a)}`;
+		const allTerminal = this.isRowTerminal(d) && this.isRowTerminal(a);
+		const marker = allTerminal
+			? "✔"
+			: this.isTTY
+				? this.spinnerFrames[this.spinnerIndex]
+				: "...";
+		return `${marker}  ${left}  ·  ${right}`;
+	}
+
+	private render(): void {
+		const line = this.formatCombined();
+		if (this.hasRendered) {
+			readline.moveCursor(process.stdout, 0, -1);
+		}
+		readline.clearLine(process.stdout, 0);
+		process.stdout.write(`${line}\n`);
+		this.hasRendered = true;
+	}
+}

--- a/src/client/database/DatabaseClient.ts
+++ b/src/client/database/DatabaseClient.ts
@@ -4,7 +4,7 @@ import type {
 	CreatePageResponse,
 	GetPageResponse,
 } from "@notionhq/client/build/src/api-endpoints";
-import { AST_RUNTIME_CONSTANTS } from "../../ast/shared/constants";
+import { PACKAGE_RUNTIME_CONSTANTS } from "../../runtime-constants";
 import { objectKeys } from "../../typeUtils";
 import {
 	buildCreatePageParametersForDataSource,
@@ -89,7 +89,7 @@ export class DatabaseClient<Definition extends DatabaseDefinition> {
 
 		this.client = new Client({
 			auth: args.auth,
-			notionVersion: AST_RUNTIME_CONSTANTS.NOTION_API_VERSION,
+			notionVersion: PACKAGE_RUNTIME_CONSTANTS.NOTION_API_VERSION,
 			fetch: fetchImpl,
 		});
 		this.id = args.id;
@@ -120,7 +120,7 @@ export class DatabaseClient<Definition extends DatabaseDefinition> {
 		});
 		if (!isFullPage(page) || !isPageInDataSource(page, this.id)) {
 			throw new Error(
-				`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} ${args.operationName}(): page ${args.pageId} does not belong to database ${this.name ?? this.id}.`,
+				`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} ${args.operationName}(): page ${args.pageId} does not belong to database ${this.name ?? this.id}.`,
 			);
 		}
 		return page;
@@ -249,7 +249,7 @@ export class DatabaseClient<Definition extends DatabaseDefinition> {
 		const projection = normalizeProjection(args);
 		if (!args.where.id) {
 			throw new Error(
-				`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} findUnique(): where.id must be a non-empty string (Notion page id).`,
+				`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} findUnique(): where.id must be a non-empty string (Notion page id).`,
 			);
 		}
 		try {
@@ -316,11 +316,18 @@ export class DatabaseClient<Definition extends DatabaseDefinition> {
 	}
 
 	public async createMany(
-		args: CreateMany<CreateSchema<Definition>>,
+		items: CreateMany<CreateSchema<Definition>>,
 	): Promise<CreatePageResponse[]> {
+		if (!Array.isArray(items)) {
+			throw new Error(
+				`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} createMany(): expected an array of create args (\`[{ properties, icon?, cover?, markdown? }]\`). The \`{ properties: [...] }\` and \`{ items: [...] }\` shapes were removed; pass the array directly.`,
+			);
+		}
+		// Sequential: no bulk endpoint, Notion rate-limits ~3 req/sec, and this
+		// preserves partial-failure order. Swap to bounded concurrency if needed.
 		const results: CreatePageResponse[] = [];
-		for (const properties of args.properties) {
-			results.push(await this.create({ properties }));
+		for (const item of items) {
+			results.push(await this.create(item));
 		}
 		return results;
 	}
@@ -330,12 +337,12 @@ export class DatabaseClient<Definition extends DatabaseDefinition> {
 	): Promise<void> {
 		if (!args.where.id) {
 			throw new Error(
-				`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} update(): where.id must be a non-empty string (Notion page id).`,
+				`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} update(): where.id must be a non-empty string (Notion page id).`,
 			);
 		}
 		if (!args.properties || objectKeys(args.properties).length === 0) {
 			throw new Error(
-				`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} update(): pass at least one key in properties.`,
+				`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} update(): pass at least one key in properties.`,
 			);
 		}
 		const properties = mapDatabaseSchemaToNotionPropertyMap({
@@ -393,14 +400,14 @@ export class DatabaseClient<Definition extends DatabaseDefinition> {
 		});
 		if (matches.length > 1) {
 			throw new Error(
-				`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} upsert(): more than one row matches where. Tighten where, delete duplicates, or use updateMany/create explicitly.`,
+				`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} upsert(): more than one row matches where. Tighten where, delete duplicates, or use updateMany/create explicitly.`,
 			);
 		}
 		const existing = matches[0];
 		if (existing) {
 			if (!args.update || objectKeys(args.update).length === 0) {
 				throw new Error(
-					`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} upsert(): when a matching row exists, pass at least one key in update.`,
+					`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} upsert(): when a matching row exists, pass at least one key in update.`,
 				);
 			}
 			const properties = mapDatabaseSchemaToNotionPropertyMap({
@@ -420,7 +427,7 @@ export class DatabaseClient<Definition extends DatabaseDefinition> {
 	public async delete(args: Delete): Promise<void> {
 		if (!args.where.id) {
 			throw new Error(
-				`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} delete(): where.id must be a non-empty string (Notion page id).`,
+				`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} delete(): where.id must be a non-empty string (Notion page id).`,
 			);
 		}
 		await this.retrievePageForCurrentDataSource({

--- a/src/client/database/create/property-value.ts
+++ b/src/client/database/create/property-value.ts
@@ -1,5 +1,5 @@
 import type { CreatePageParameters } from "@notionhq/client/build/src/api-endpoints";
-import { AST_RUNTIME_CONSTANTS } from "../../../ast/shared/constants";
+import { PACKAGE_RUNTIME_CONSTANTS } from "../../../runtime-constants";
 import type { SupportedNotionColumnType } from "../types";
 import { toNotionPageId } from "../types/notion-page-id";
 import type { NotWritableDatabaseColumnType } from "../types/schema";
@@ -52,7 +52,7 @@ function describeRuntimeValue(value: unknown): string {
 
 function unsupportedAddTypeError(type: SupportedNotionColumnType): Error {
 	return new Error(
-		`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} create() does not support property type '${type}'. This property type is readable in query responses but cannot be written via create().`,
+		`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} create() does not support property type '${type}'. This property type is readable in query responses but cannot be written via create().`,
 	);
 }
 
@@ -62,7 +62,7 @@ function invalidAddValueError(args: {
 }): Error {
 	const actual = describeRuntimeValue(args.value);
 	return new Error(
-		`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} create() received invalid value for property type '${args.type}'. Received ${actual}.`,
+		`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} create() received invalid value for property type '${args.type}'. Received ${actual}.`,
 	);
 }
 

--- a/src/client/database/query/build-query-response.ts
+++ b/src/client/database/query/build-query-response.ts
@@ -1,5 +1,6 @@
 import type { QueryDataSourceResponse } from "@notionhq/client/build/src/api-endpoints";
 import type { DatabaseColumns } from "../types";
+import type { DatabasePropertyValue } from "../types";
 import type {
 	QueryResponseWithoutRawResponse,
 	QueryResponseWithRawResponse,
@@ -14,7 +15,7 @@ import {
  * schema so drift is surfaced without paying a validation cost on every row.
  */
 function mapQueryResults<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 >(args: {
 	results: QueryDataSourceResponse["results"];
 	columns: DatabaseColumns;
@@ -45,7 +46,7 @@ function mapQueryResults<
 }
 
 type BuildQueryResponseBase<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 > = {
 	response: QueryDataSourceResponse;
 	columns: DatabaseColumns;
@@ -53,29 +54,29 @@ type BuildQueryResponseBase<
 };
 
 type BuildQueryResponseWithRawResponse<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 > = BuildQueryResponseBase<DatabaseSchemaType> & {
 	options: { includeRawResponse: true };
 };
 
 type BuildQueryResponseInput<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 > = BuildQueryResponseBase<DatabaseSchemaType> & {
 	options?: { includeRawResponse?: false | undefined };
 };
 
 export function buildQueryResponse<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 >(
 	args: BuildQueryResponseWithRawResponse<DatabaseSchemaType>,
 ): QueryResponseWithRawResponse<DatabaseSchemaType>;
 export function buildQueryResponse<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 >(
 	args: BuildQueryResponseInput<DatabaseSchemaType>,
 ): QueryResponseWithoutRawResponse<DatabaseSchemaType>;
 export function buildQueryResponse<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 >(
 	args:
 		| BuildQueryResponseInput<DatabaseSchemaType>

--- a/src/client/database/query/normalize-page-result.ts
+++ b/src/client/database/query/normalize-page-result.ts
@@ -5,7 +5,7 @@ import type {
 } from "@notionhq/client/build/src/api-endpoints";
 import { camelize } from "../../../helpers";
 import { objectEntries } from "../../../typeUtils";
-import type { DatabaseColumns } from "../types";
+import type { DatabaseColumns, DatabasePropertyValue } from "../types";
 import { getSimplifiedResult } from "./response";
 import type {
 	NormalizablePageResult,
@@ -37,11 +37,8 @@ export function isPageInDataSource(
 
 /** Converts a raw Notion page into the camelized shape exposed by the client. */
 export function normalizePageResult<
-	DatabaseSchemaType extends Record<string, unknown>,
->(args: {
-	result: NormalizablePageResult;
-	columns: DatabaseColumns;
-}) {
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
+>(args: { result: NormalizablePageResult; columns: DatabaseColumns }) {
 	const normalizedResult: Partial<DatabaseSchemaType> = {};
 	for (const [columnName, propertyValue] of objectEntries(
 		args.result.properties,

--- a/src/client/database/query/projection.ts
+++ b/src/client/database/query/projection.ts
@@ -1,9 +1,8 @@
-import { AST_RUNTIME_CONSTANTS } from "../../../ast/shared/constants";
+import { PACKAGE_RUNTIME_CONSTANTS } from "../../../runtime-constants";
 import type {
 	DatabasePropertyValue,
 	Projection,
 	ProjectionPropertyName,
-	ProjectionSelection,
 } from "../types";
 
 export type NormalizedProjection<PropertyName extends string | number> = {
@@ -22,7 +21,7 @@ export function normalizeProjection<
 	const hasOmit = omit != null && omit.length > 0;
 	if (hasSelect && hasOmit) {
 		throw new Error(
-			`${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} Projection: use either select or omit, not both.`,
+			`${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} Projection: use either select or omit, not both.`,
 		);
 	}
 	if (hasSelect) {

--- a/src/client/database/query/schema-drift-validation.ts
+++ b/src/client/database/query/schema-drift-validation.ts
@@ -1,4 +1,4 @@
-import { AST_RUNTIME_CONSTANTS } from "../../../ast/shared/constants";
+import { PACKAGE_RUNTIME_CONSTANTS } from "../../../runtime-constants";
 import { objectKeys } from "../../../typeUtils";
 import type { DatabaseColumns } from "../types";
 import type { DatabasePropertyValue } from "../types";
@@ -55,13 +55,13 @@ export function validateDatabaseQueryRow<
 			args.loggedSchemaValidationIssues.add(issueSignature);
 			// biome-ignore lint/suspicious/noConsole: surface schema drift
 			console.error(
-				`⚠️ ${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} ${
-					AST_RUNTIME_CONSTANTS.SCHEMA_DRIFT_PREFIX
+				`⚠️ ${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} ${
+					PACKAGE_RUNTIME_CONSTANTS.SCHEMA_DRIFT_PREFIX
 				} for the following Notion database ${schemaLabel}
 					\nMissing properties: ${missingProperties
 						.map((prop) => `\`${prop}\``)
 						.join(", ")}
-					\n\n✅ ${AST_RUNTIME_CONSTANTS.SCHEMA_DRIFT_HELP_MESSAGE}
+					\n\n✅ ${PACKAGE_RUNTIME_CONSTANTS.SCHEMA_DRIFT_HELP_MESSAGE}
 					`,
 			);
 		}
@@ -78,9 +78,9 @@ export function validateDatabaseQueryRow<
 				args.loggedSchemaValidationIssues.add(issueSignature);
 				// biome-ignore lint/suspicious/noConsole: unexpected remote properties
 				console.error(
-					`⚠️ ${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} ${AST_RUNTIME_CONSTANTS.SCHEMA_DRIFT_PREFIX} for the following Notion database ${schemaLabel}
+					`⚠️ ${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} ${PACKAGE_RUNTIME_CONSTANTS.SCHEMA_DRIFT_PREFIX} for the following Notion database ${schemaLabel}
 						\nUnexpected property found in remote data: \`${remoteColName}\`
-						\n\n✅ ${AST_RUNTIME_CONSTANTS.SCHEMA_DRIFT_HELP_MESSAGE}
+						\n\n✅ ${PACKAGE_RUNTIME_CONSTANTS.SCHEMA_DRIFT_HELP_MESSAGE}
 						`,
 				);
 			}
@@ -104,8 +104,8 @@ export function validateDatabaseQueryRow<
 		args.loggedSchemaValidationIssues.add(issueSignature);
 		// biome-ignore lint/suspicious/noConsole: schema validation failures
 		console.error(
-			`⚠️ ${AST_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} ${
-				AST_RUNTIME_CONSTANTS.SCHEMA_DRIFT_PREFIX
+			`⚠️ ${PACKAGE_RUNTIME_CONSTANTS.PACKAGE_LOG_PREFIX} ${
+				PACKAGE_RUNTIME_CONSTANTS.SCHEMA_DRIFT_PREFIX
 			} for the following Notion database ${schemaLabel}
 			\nValidation issues: ${parseError.issues
 				.map(
@@ -113,7 +113,7 @@ export function validateDatabaseQueryRow<
 						`\`${issue.path.join(".")}: ${issue.message}\``,
 				)
 				.join(", ")}
-			\n\n✅ ${AST_RUNTIME_CONSTANTS.SCHEMA_DRIFT_HELP_MESSAGE}
+			\n\n✅ ${PACKAGE_RUNTIME_CONSTANTS.SCHEMA_DRIFT_HELP_MESSAGE}
 			`,
 		);
 	}

--- a/src/client/database/query/types.ts
+++ b/src/client/database/query/types.ts
@@ -4,6 +4,7 @@ import type {
 	QueryDataSourceResponse,
 } from "@notionhq/client/build/src/api-endpoints";
 import type {
+	DatabasePropertyValue,
 	DatabaseDefinition,
 	FilterableNotionColumnType,
 	QueryFilter,
@@ -28,7 +29,9 @@ export type NormalizablePageResult =
 	| QueryDataSourcePageResultWithProperties
 	| PageObjectResponse;
 
-export type ResponseResolver = (property: NotionPropertyValue) => unknown;
+export type ResponseResolver = (
+	property: NotionPropertyValue,
+) => DatabasePropertyValue;
 
 export type ResponseResolverRegistry = Record<
 	SupportedNotionColumnType,

--- a/src/client/database/types/crud.ts
+++ b/src/client/database/types/crud.ts
@@ -19,9 +19,7 @@ export type Create<Y extends SchemaRecord> = {
 	markdown?: CreatePageParameters["markdown"];
 };
 
-export type CreateMany<Y extends SchemaRecord> = {
-	properties: Y[];
-};
+export type CreateMany<Y extends SchemaRecord> = ReadonlyArray<Create<Y>>;
 
 export type Update<Y extends SchemaRecord> = {
 	where: { id: string };

--- a/src/config/findConfigFile.ts
+++ b/src/config/findConfigFile.ts
@@ -5,7 +5,7 @@ import {
 	NOTION_CONFIG_FILENAMES,
 } from "./notion-config-filenames";
 
-export type NotionConfigFile = {
+type NotionConfigFile = {
 	path: string;
 	isTS: boolean;
 };

--- a/src/config/findConfigFile.ts
+++ b/src/config/findConfigFile.ts
@@ -1,0 +1,26 @@
+import fs from "fs";
+import path from "path";
+import {
+	NOTION_CONFIG_CANDIDATE_FILENAMES,
+	NOTION_CONFIG_FILENAMES,
+} from "./notion-config-filenames";
+
+export type NotionConfigFile = {
+	path: string;
+	isTS: boolean;
+};
+
+/** Looks for supported notion config filenames in the same order as the loader. */
+export function findConfigFile(): NotionConfigFile | undefined {
+	const projectDir = process.cwd();
+	for (const filename of NOTION_CONFIG_CANDIDATE_FILENAMES) {
+		const candidatePath = path.join(projectDir, filename);
+		if (fs.existsSync(candidatePath)) {
+			return {
+				path: candidatePath,
+				isTS: filename === NOTION_CONFIG_FILENAMES.ts,
+			};
+		}
+	}
+	return undefined;
+}

--- a/src/config/helpers.ts
+++ b/src/config/helpers.ts
@@ -5,7 +5,16 @@ import {
 } from "../cli/helpers";
 import fs from "fs";
 import path from "path";
+import {
+	NOTION_CONFIG_CANDIDATE_FILENAMES,
+	NOTION_CONFIG_FILENAMES,
+} from "./notion-config-filenames";
 import { getNotionConfig } from "./loadConfig";
+
+/** Filename used by `notion init` when creating a new config file. */
+function getNotionConfigInitFilename(isTS: boolean): string {
+	return isTS ? NOTION_CONFIG_FILENAMES.ts : NOTION_CONFIG_FILENAMES.js;
+}
 
 export type NotionConfigType = {
 	auth: string;
@@ -45,7 +54,7 @@ export async function initializeNotionConfigFile(
 		const isTS =
 			options.force === "ts" ||
 			(options.force !== "js" && shouldUseTypeScript());
-		const filename = isTS ? "notion.config.ts" : "notion.config.js";
+		const filename = getNotionConfigInitFilename(isTS);
 		const configPath = path.join(process.cwd(), filename);
 
 		if (fs.existsSync(configPath)) {
@@ -85,18 +94,14 @@ export function findConfigFile():
 	  }
 	| undefined {
 	const projDir = process.cwd();
-	const notionConfigPathJS = path.join(projDir, "notion.config.js");
-	const notionConfigPathTS = path.join(projDir, "notion.config.ts");
-	const notionConfigPathMJS = path.join(projDir, "notion.config.mjs");
-
-	if (fs.existsSync(notionConfigPathJS)) {
-		return { path: notionConfigPathJS, isTS: false };
-	}
-	if (fs.existsSync(notionConfigPathTS)) {
-		return { path: notionConfigPathTS, isTS: true };
-	}
-	if (fs.existsSync(notionConfigPathMJS)) {
-		return { path: notionConfigPathMJS, isTS: false };
+	for (const filename of NOTION_CONFIG_CANDIDATE_FILENAMES) {
+		const candidatePath = path.join(projDir, filename);
+		if (fs.existsSync(candidatePath)) {
+			return {
+				path: candidatePath,
+				isTS: filename === NOTION_CONFIG_FILENAMES.ts,
+			};
+		}
 	}
 	return undefined;
 }

--- a/src/config/helpers.ts
+++ b/src/config/helpers.ts
@@ -8,7 +8,6 @@ import {
 } from "./init";
 import { NOTION_CONFIG_FILENAMES } from "./notion-config-filenames";
 import { getNotionConfig } from "./loadConfig";
-export type { NotionConfigType } from "./types";
 
 /** Filename used by `notion init` when creating a new config file. */
 function getNotionConfigInitFilename(isTS: boolean): string {

--- a/src/config/helpers.ts
+++ b/src/config/helpers.ts
@@ -1,107 +1,79 @@
+import fs from "fs";
+import path from "path";
+import { findConfigFile } from "./findConfigFile";
 import {
 	createConfigTemplate,
 	shouldUseTypeScript,
 	showSetupInstructions,
-} from "../cli/helpers";
-import fs from "fs";
-import path from "path";
-import {
-	NOTION_CONFIG_CANDIDATE_FILENAMES,
-	NOTION_CONFIG_FILENAMES,
-} from "./notion-config-filenames";
+} from "./init";
+import { NOTION_CONFIG_FILENAMES } from "./notion-config-filenames";
 import { getNotionConfig } from "./loadConfig";
+export type { NotionConfigType } from "./types";
 
 /** Filename used by `notion init` when creating a new config file. */
 function getNotionConfigInitFilename(isTS: boolean): string {
 	return isTS ? NOTION_CONFIG_FILENAMES.ts : NOTION_CONFIG_FILENAMES.js;
 }
 
-export type NotionConfigType = {
-	auth: string;
-	databases: string[];
-	agents: string[];
-};
-
 /** Verifies that config can be resolved and parsed before running CLI commands. */
 export async function validateConfig(): Promise<void> {
-		try {
-			await getNotionConfig();
-		} catch (error: unknown) {
-			console.error("❌ Invalid notion config");
-			if (error instanceof Error) {
-				console.error(`   ${error.message}`);
-			}
-			showSetupInstructions();
-			process.exit(1);
+	try {
+		await getNotionConfig();
+	} catch (error: unknown) {
+		console.error("❌ Invalid notion config");
+		if (error instanceof Error) {
+			console.error(`   ${error.message}`);
 		}
+		showSetupInstructions();
+		process.exit(1);
 	}
+}
 
 /** Creates a starter config file unless one already exists in the project root. */
 export async function initializeNotionConfigFile(
-		options: { force?: "ts" | "js" } = {},
-	): Promise<void> {
-		const existingConfig = findConfigFile();
+	options: { force?: "ts" | "js" } = {},
+): Promise<void> {
+	const existingConfig = findConfigFile();
 
-		if (existingConfig) {
-			console.log("⚠️  A notion.config file already exists:");
-			console.log(`   Found ${path.basename(existingConfig.path)}`);
-			console.log(
-				"   Skipping init. Use that file or remove it before re-running init.",
-			);
-			return;
-		}
-
-		const isTS =
-			options.force === "ts" ||
-			(options.force !== "js" && shouldUseTypeScript());
-		const filename = getNotionConfigInitFilename(isTS);
-		const configPath = path.join(process.cwd(), filename);
-
-		if (fs.existsSync(configPath)) {
-			console.log("⚠️  Config file already exists at:");
-			console.log(`   ${configPath}`);
-			console.log(
-				"   Skipping init. Remove the file if you want to regenerate it.",
-			);
-			return;
-		}
-
-		try {
-			fs.writeFileSync(configPath, createConfigTemplate(isTS));
-			console.log(
-				`✅ Created ${filename} (${isTS ? "TypeScript" : "JavaScript"})`,
-			);
-			console.log("   Next steps:");
-			console.log(
-				"   • Add your NOTION_KEY to a .env file (or export it in your shell)",
-			);
-			console.log(
-				"   • Use `notion add <data-source-id or URL>` to append databases",
-			);
-			console.log("   • Run `notion sync` to build local types");
-		} catch (error: unknown) {
-			console.error("❌ Error creating config file:");
-			console.error(error);
-			process.exit(1);
-		}
+	if (existingConfig) {
+		console.log("⚠️  A notion.config file already exists:");
+		console.log(`   Found ${path.basename(existingConfig.path)}`);
+		console.log(
+			"   Skipping init. Use that file or remove it before re-running init.",
+		);
+		return;
 	}
 
-/** Looks for supported notion config filenames in the same order as the loader. */
-export function findConfigFile():
-	| {
-			path: string;
-			isTS: boolean;
-	  }
-	| undefined {
-	const projDir = process.cwd();
-	for (const filename of NOTION_CONFIG_CANDIDATE_FILENAMES) {
-		const candidatePath = path.join(projDir, filename);
-		if (fs.existsSync(candidatePath)) {
-			return {
-				path: candidatePath,
-				isTS: filename === NOTION_CONFIG_FILENAMES.ts,
-			};
-		}
+	const isTS =
+		options.force === "ts" || (options.force !== "js" && shouldUseTypeScript());
+	const filename = getNotionConfigInitFilename(isTS);
+	const configPath = path.join(process.cwd(), filename);
+
+	if (fs.existsSync(configPath)) {
+		console.log("⚠️  Config file already exists at:");
+		console.log(`   ${configPath}`);
+		console.log(
+			"   Skipping init. Remove the file if you want to regenerate it.",
+		);
+		return;
 	}
-	return undefined;
+
+	try {
+		fs.writeFileSync(configPath, createConfigTemplate(isTS));
+		console.log(
+			`✅ Created ${filename} (${isTS ? "TypeScript" : "JavaScript"})`,
+		);
+		console.log("   Next steps:");
+		console.log(
+			"   • Add your NOTION_KEY to a .env file (or export it in your shell)",
+		);
+		console.log(
+			"   • Use `notion add <data-source-id or URL>` to append databases",
+		);
+		console.log("   • Run `notion sync` to build local types");
+	} catch (error: unknown) {
+		console.error("❌ Error creating config file:");
+		console.error(error);
+		process.exit(1);
+	}
 }

--- a/src/config/init.ts
+++ b/src/config/init.ts
@@ -1,0 +1,39 @@
+import { renderConfigTemplateModule } from "../ast/shared/emit/config-emitter";
+import { resolveCodegenEnvironment } from "../ast/shared/codegen-environment";
+
+/** Heuristic for `notion init`: TS projects get a TS config template by default. */
+export function shouldUseTypeScript(): boolean {
+	return resolveCodegenEnvironment() === "typescript";
+}
+
+/** Renders the starter config template and guarantees a trailing newline. */
+export function createConfigTemplate(isTS: boolean): string {
+	const renderedTemplate = renderConfigTemplateModule({ isTS });
+	return renderedTemplate.endsWith("\n")
+		? renderedTemplate
+		: `${renderedTemplate}\n`;
+}
+
+/** Prints setup guidance together with copy-pastable example configs. */
+export function showSetupInstructions(): void {
+	console.log("\n📚 Setup Instructions:");
+	console.log(
+		"1. Run: notion init [--ts|--js] (defaults to TypeScript when tsconfig.json is present)",
+	);
+	console.log("2. Add your Notion integration token and database IDs");
+	console.log("3. Run: notion sync (generates database types)");
+	console.log(
+		"4. (Optional) Run: notion setup-agents-sdk (installs the paid Agents SDK, then re-run notion sync)",
+	);
+
+	console.log("\n📝 Example JavaScript config (notion.config.js):");
+	console.log(`\n${createConfigTemplate(false).trimEnd()}\n`);
+
+	console.log("📝 Example TypeScript config (notion.config.ts):");
+	console.log(`\n${createConfigTemplate(true).trimEnd()}\n`);
+
+	console.log("\n🔗 Need help getting your integration token?");
+	console.log(
+		"   Visit: https://developers.notion.com/docs/create-a-notion-integration",
+	);
+}

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -2,6 +2,7 @@ import { pathToFileURL } from "url";
 import { z } from "zod";
 import type { NotionConfigType } from "./helpers";
 import { findConfigFile } from "./helpers.js";
+import { NOTION_CONFIG_EXTENSION_LABELS } from "./notion-config-filenames.js";
 
 let cachedConfig: NotionConfigType | undefined;
 
@@ -98,7 +99,7 @@ export async function getNotionConfig(): Promise<NotionConfigType> {
 		}
 
 		throw new Error(
-			"No notion.config.js/ts/mjs file found and no NOTION_KEY environment variable set. " +
+			`No notion.config.${NOTION_CONFIG_EXTENSION_LABELS} file found and no NOTION_KEY environment variable set. ` +
 				"Please create a config file or set NOTION_KEY.",
 		);
 	}

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,16 +1,10 @@
 import { pathToFileURL } from "url";
-import { z } from "zod";
-import type { NotionConfigType } from "./helpers";
-import { findConfigFile } from "./helpers.js";
+import { findConfigFile } from "./findConfigFile.js";
+import { loadDotEnvFromCwd } from "./loadDotEnvFromCwd";
 import { NOTION_CONFIG_EXTENSION_LABELS } from "./notion-config-filenames.js";
+import { notionConfigSchema, type NotionConfigType } from "./types";
 
 let cachedConfig: NotionConfigType | undefined;
-
-const notionConfigSchema = z.object({
-	auth: z.string().min(1, "Missing 'auth' field in notion config"),
-	databases: z.array(z.string()),
-	agents: z.array(z.string()),
-});
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -38,17 +32,14 @@ function parseNotionConfig(input: unknown): NotionConfigType {
 }
 
 /**
- * Dynamically loads the user's notion.config file.
- * - Works with Bun (native TS support)
- * - Works with Node.js (ESM and CJS)
- * - Supports .ts, .js, .mjs config files
+ * Dynamically loads the user's notion.config file via `import()`.
+ * Use a `file://` URL so Node, Bun, and other ESM runtimes resolve the path consistently.
+ * Plain Node loads `.js`/`.mjs` natively; `.ts` requires a runtime that can execute TypeScript
+ * (or compile the config to JavaScript first).
  */
 async function loadUserConfig(absolutePath: string): Promise<unknown> {
-	const isBun = "Bun" in globalThis;
-
-	// 1) Try dynamic import first (works for Bun with .ts, Node with .js/.mjs)
 	try {
-		const importPath = isBun ? absolutePath : pathToFileURL(absolutePath).href;
+		const importPath = pathToFileURL(absolutePath).href;
 		const mod = await import(importPath);
 		return mod.default ?? mod;
 	} catch (error: unknown) {
@@ -59,16 +50,19 @@ async function loadUserConfig(absolutePath: string): Promise<unknown> {
 }
 
 /** Loads and validates a user config module from a known path. */
-export async function loadConfig(configPath: string): Promise<NotionConfigType> {
-		try {
-			const config = await loadUserConfig(configPath);
-			return parseNotionConfig(config);
-		} catch (error: unknown) {
-			throw new Error(
-				`Failed to load config from ${configPath}: ${getErrorMessage(error)}`,
-			);
-		}
+export async function loadConfig(
+	configPath: string,
+): Promise<NotionConfigType> {
+	try {
+		loadDotEnvFromCwd();
+		const config = await loadUserConfig(configPath);
+		return parseNotionConfig(config);
+	} catch (error: unknown) {
+		throw new Error(
+			`Failed to load config from ${configPath}: ${getErrorMessage(error)}`,
+		);
 	}
+}
 
 /**
  * Resolves config once per process, falling back to environment variables when
@@ -80,6 +74,8 @@ export async function getNotionConfig(): Promise<NotionConfigType> {
 		return cachedConfig;
 	}
 
+	loadDotEnvFromCwd();
+
 	// Try to find config file
 	const configFile = findConfigFile();
 
@@ -87,13 +83,11 @@ export async function getNotionConfig(): Promise<NotionConfigType> {
 		// Fallback to environment variable
 		const authFromEnv = process.env.NOTION_KEY;
 		if (authFromEnv) {
-			const databases: string[] = [];
-			const agents: string[] = [];
-			const config: NotionConfigType = {
+			const config = parseNotionConfig({
 				auth: authFromEnv,
-				databases,
-				agents,
-			};
+				databases: [],
+				agents: [],
+			});
 			cachedConfig = config;
 			return config;
 		}

--- a/src/config/loadDotEnvFromCwd.ts
+++ b/src/config/loadDotEnvFromCwd.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import path from "path";
+import { config as loadDotEnv } from "dotenv";
+
+const DOT_ENV_FILENAME = ".env";
+const loadedDirectories = new Set<string>();
+
+function getDotEnvCandidateFilenames(nodeEnv: string | undefined): string[] {
+	const candidates = [
+		nodeEnv ? `${DOT_ENV_FILENAME}.${nodeEnv}.local` : undefined,
+		`${DOT_ENV_FILENAME}.local`,
+		nodeEnv ? `${DOT_ENV_FILENAME}.${nodeEnv}` : undefined,
+		DOT_ENV_FILENAME,
+	];
+	return Array.from(new Set(candidates.filter((value) => value !== undefined)));
+}
+
+/**
+ * Loads `.env*` files from the current project root using a runtime-agnostic cascade.
+ * Explicit shell environment variables always win over file values.
+ *
+ * Precedence (highest to lowest):
+ * 1) `.env.<NODE_ENV>.local`
+ * 2) `.env.local`
+ * 3) `.env.<NODE_ENV>`
+ * 4) `.env`
+ */
+export function loadDotEnvFromCwd(): void {
+	const cwd = process.cwd();
+	if (loadedDirectories.has(cwd)) {
+		return;
+	}
+
+	for (const filename of getDotEnvCandidateFilenames(process.env.NODE_ENV)) {
+		const envPath = path.join(cwd, filename);
+		if (!fs.existsSync(envPath)) {
+			continue;
+		}
+
+		const result = loadDotEnv({
+			path: envPath,
+			override: false,
+			processEnv: process.env,
+			quiet: true,
+		});
+		if (result.error) {
+			console.warn(
+				`Warning: failed to parse ${envPath}: ${result.error.message}`,
+			);
+		}
+	}
+
+	loadedDirectories.add(cwd);
+}

--- a/src/config/notion-config-filenames.ts
+++ b/src/config/notion-config-filenames.ts
@@ -1,0 +1,29 @@
+/**
+ * Single source of truth for user project `notion.config.*` filenames (CLI
+ * discovery, init, and tests). Keep this dumb: one basename plus the few
+ * concrete filenames we support.
+ */
+
+/** Basename (no extension) for the Notion ORM config module in consuming apps. */
+export const NOTION_CONFIG_BASENAME = "notion.config" as const;
+
+export const NOTION_CONFIG_FILENAMES = {
+	js: `${NOTION_CONFIG_BASENAME}.js`,
+	ts: `${NOTION_CONFIG_BASENAME}.ts`,
+	mjs: `${NOTION_CONFIG_BASENAME}.mjs`,
+} as const;
+
+/**
+ * Supported filenames probed by {@link findConfigFile} in discovery order.
+ * `.js` stays ahead of `.ts` for legacy compatibility when both exist.
+ */
+export const NOTION_CONFIG_CANDIDATE_FILENAMES = [
+	NOTION_CONFIG_FILENAMES.js,
+	NOTION_CONFIG_FILENAMES.ts,
+	NOTION_CONFIG_FILENAMES.mjs,
+] as const;
+
+/** Human-readable fragment for diagnostics (e.g. `js/ts/mjs`), derived from candidates. */
+export const NOTION_CONFIG_EXTENSION_LABELS = NOTION_CONFIG_CANDIDATE_FILENAMES.map(
+	(filename) => filename.slice(NOTION_CONFIG_BASENAME.length + 1),
+).join("/");

--- a/src/config/resolveNotionAuth.ts
+++ b/src/config/resolveNotionAuth.ts
@@ -1,3 +1,5 @@
+import { loadDotEnvFromCwd } from "./loadDotEnvFromCwd";
+
 /**
  * Input accepted by {@link resolveNotionAuth} and {@link NotionORMBase}.
  */
@@ -6,18 +8,24 @@ export type NotionORMConfig = {
 };
 
 /**
- * Resolves the Notion API token from explicit `config.auth` or `process.env.NOTION_KEY`.
+ * Resolves the Notion API token using a single, predictable precedence:
+ *
+ * 1. Explicit `config.auth` (trimmed, when non-empty).
+ * 2. `process.env.NOTION_KEY` — populated either by the shell or by a `.env`
+ *    file in the current project root, which this module loads automatically
+ *    (shell values always win over `.env` values).
  *
  * @throws Error with actionable guidance when neither yields a non-empty string.
  */
 export function resolveNotionAuth(config: NotionORMConfig): string {
+	loadDotEnvFromCwd();
 	const token = config.auth?.trim() || process.env.NOTION_KEY?.trim();
 	if (token === undefined || token.length === 0) {
 		throw new Error(
 			[
 				"Missing Notion API credentials.",
 				"Pass `auth` when constructing NotionORM (for example `new NotionORM({ auth: process.env.NOTION_KEY })`),",
-				"or set the NOTION_KEY environment variable (for example in a `.env` file loaded by your runtime).",
+				"or set the NOTION_KEY environment variable in your shell or in a `.env` file at your project root.",
 			].join(" "),
 		);
 	}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const notionConfigSchema = z.object({
+	auth: z.string().min(1, "Missing 'auth' field in notion config"),
+	databases: z.array(z.string()),
+	agents: z.array(z.string()),
+});
+
+export type NotionConfigType = z.infer<typeof notionConfigSchema>;

--- a/src/runtime-constants.ts
+++ b/src/runtime-constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Runtime-only constants shared by the published package surface, CLI, and
+ * generated clients. Keeping these outside `src/ast/` avoids making runtime
+ * code look like it depends on codegen internals.
+ */
+export const PACKAGE_RUNTIME_CONSTANTS = {
+	NOTION_API_VERSION: "2026-03-11",
+
+	PACKAGE_LOG_PREFIX: "[@haustle/notion-orm]",
+
+	CLI_GENERATE_COMMAND: "notion sync",
+
+	SCHEMA_DRIFT_PREFIX: "Schema drift detected",
+
+	SCHEMA_DRIFT_HELP_MESSAGE:
+		"To easily fix this, please run `notion sync` to refresh all database schemas.",
+} as const;

--- a/tests/cli/command-routing.integration.test.ts
+++ b/tests/cli/command-routing.integration.test.ts
@@ -1,29 +1,38 @@
-import { describe, expect, test } from "bun:test";
-import { join } from "path";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
-const cliEntryPath = join(import.meta.dir, "../../src/cli/index.ts");
 const repoRoot = join(import.meta.dir, "../..");
+const builtCliPath = join(repoRoot, "build/src/cli/index.js");
+
+beforeAll(() => {
+	if (!existsSync(builtCliPath)) {
+		execSync("npm run build", { cwd: repoRoot, stdio: "pipe" });
+	}
+});
 
 function runCli(args: string[]) {
-	return Bun.spawnSync({
-		cmd: ["bun", cliEntryPath, ...args],
+	// Use the `node` binary explicitly: under `bun test`, `process.execPath` is Bun,
+	// which resolves the built CLI's imports differently than Node users.
+	return spawnSync("node", [builtCliPath, ...args], {
 		cwd: repoRoot,
-		stdout: "pipe",
-		stderr: "pipe",
+		encoding: "utf-8",
+		env: process.env,
 	});
 }
 
 describe("CLI index integration", () => {
 	test("prints help output for help command", () => {
 		const output = runCli(["help"]);
-		expect(output.exitCode).toBe(0);
-		expect(output.stdout.toString()).toContain("Notion ORM CLI");
+		expect(output.status).toBe(0);
+		expect(output.stdout).toContain("Notion ORM CLI");
 	});
 
 	test("help output includes setup-agents-sdk command", () => {
 		const output = runCli(["help"]);
-		expect(output.exitCode).toBe(0);
-		expect(output.stdout.toString()).toContain("setup-agents-sdk");
+		expect(output.status).toBe(0);
+		expect(output.stdout).toContain("setup-agents-sdk");
 	});
 
 	test("fails for invalid add type", () => {
@@ -33,16 +42,16 @@ describe("CLI index integration", () => {
 			"--type",
 			"agent",
 		]);
-		expect(output.exitCode).toBe(1);
-		expect(output.stderr.toString()).toContain(
+		expect(output.status).toBe(1);
+		expect(output.stderr).toContain(
 			"Invalid --type value. Must be 'database'",
 		);
 	});
 
 	test("fails when both --ts and --js are provided for init", () => {
 		const output = runCli(["init", "--ts", "--js"]);
-		expect(output.exitCode).toBe(1);
-		expect(output.stderr.toString()).toContain(
+		expect(output.status).toBe(1);
+		expect(output.stderr).toContain(
 			"Cannot use both --ts and --js flags together",
 		);
 	});

--- a/tests/codegen/database-emitter.test.ts
+++ b/tests/codegen/database-emitter.test.ts
@@ -23,7 +23,7 @@ import {
 	expectCodeToParseAsValidTs,
 	readGolden,
 } from "../helpers/golden-code-assertions";
-afterEach(() => undefined);
+afterEach((): void => undefined);
 
 function renderFixture(fixture: DataSourceFixtureSpec) {
 	return renderDatabaseModule(buildMockDataSourceResponse(fixture));

--- a/tests/codegen/database-emitter.test.ts
+++ b/tests/codegen/database-emitter.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { join } from "path";
-import { pathToFileURL } from "url";
 import { renderDatabaseModule } from "../../src/ast/database/database-file-writer";
 import {
 	isSupportedPropertyType,
@@ -11,7 +9,6 @@ import { objectKeys } from "../../src/typeUtils";
 import {
 	CODEGEN_EMIT_PATHS,
 	CODEGEN_GOLDEN_FILES,
-	CODEGEN_TEST_PATHS,
 } from "../helpers/codegen-file-names";
 import {
 	ALL_DATABASE_FIXTURES,
@@ -26,15 +23,7 @@ import {
 	expectCodeToParseAsValidTs,
 	readGolden,
 } from "../helpers/golden-code-assertions";
-import {
-	cleanupTempWorkspaces,
-	createTempWorkspace,
-	writeWorkspaceFile,
-} from "../helpers/temp-workspace";
-
-afterEach(() => {
-	cleanupTempWorkspaces();
-});
+afterEach(() => undefined);
 
 function renderFixture(fixture: DataSourceFixtureSpec) {
 	return renderDatabaseModule(buildMockDataSourceResponse(fixture));
@@ -59,22 +48,10 @@ describe("database module emitter", () => {
 			expect(rendered.tsCode).toBe(golden);
 		});
 
-		test("emits JavaScript source that matches the customerOrders golden", () => {
-			const golden = readGolden(CODEGEN_GOLDEN_FILES.dbCustomerOrdersJs);
-			expect(rendered.jsCode).toBe(golden);
-		});
-
 		test("produces TypeScript output that parses successfully", () => {
 			expectCodeToParseAsValidTs({
 				code: rendered.tsCode,
 				fileName: CODEGEN_EMIT_PATHS.customerOrdersModuleTs,
-			});
-		});
-
-		test("produces JavaScript output that parses successfully", () => {
-			expectCodeToParseAsValidJs({
-				code: rendered.jsCode,
-				fileName: CODEGEN_EMIT_PATHS.customerOrdersModuleJs,
 			});
 		});
 	});
@@ -93,22 +70,10 @@ describe("database module emitter", () => {
 			expect(rendered.tsCode).toBe(golden);
 		});
 
-		test("emits JavaScript source that matches the inventoryItems golden", () => {
-			const golden = readGolden(CODEGEN_GOLDEN_FILES.dbInventoryItemsJs);
-			expect(rendered.jsCode).toBe(golden);
-		});
-
 		test("produces TypeScript output that parses successfully", () => {
 			expectCodeToParseAsValidTs({
 				code: rendered.tsCode,
 				fileName: CODEGEN_EMIT_PATHS.inventoryItemsModuleTs,
-			});
-		});
-
-		test("produces JavaScript output that parses successfully", () => {
-			expectCodeToParseAsValidJs({
-				code: rendered.jsCode,
-				fileName: CODEGEN_EMIT_PATHS.inventoryItemsModuleJs,
 			});
 		});
 	});
@@ -127,22 +92,10 @@ describe("database module emitter", () => {
 			expect(rendered.tsCode).toBe(golden);
 		});
 
-		test("emits JavaScript source that matches the edgeCases golden", () => {
-			const golden = readGolden(CODEGEN_GOLDEN_FILES.dbEdgeCasesJs);
-			expect(rendered.jsCode).toBe(golden);
-		});
-
 		test("produces TypeScript output that parses successfully", () => {
 			expectCodeToParseAsValidTs({
 				code: rendered.tsCode,
 				fileName: CODEGEN_EMIT_PATHS.edgeCasesModuleTs,
-			});
-		});
-
-		test("produces JavaScript output that parses successfully", () => {
-			expectCodeToParseAsValidJs({
-				code: rendered.jsCode,
-				fileName: CODEGEN_EMIT_PATHS.edgeCasesModuleJs,
 			});
 		});
 
@@ -156,53 +109,6 @@ describe("database module emitter", () => {
 		});
 	});
 
-	// -----------------------------------------------------------------------
-	// Runtime import tests -- emitted JS can actually be loaded
-	// -----------------------------------------------------------------------
-
-	describe("runtime import", () => {
-		function writeDependencyStubs(workspacePath: string): void {
-			writeWorkspaceFile({
-				workspacePath,
-				relativePath: CODEGEN_TEST_PATHS.notionOrmModuleIndexJs,
-				content:
-					"class DatabaseClient { constructor(args) { this.args = args; } }\nmodule.exports = { DatabaseClient };\n",
-			});
-			writeWorkspaceFile({
-				workspacePath,
-				relativePath: CODEGEN_TEST_PATHS.zodModuleIndexJs,
-				content: [
-					"const handler = { get(_, prop) { return prop === 'object' ? (o) => chain : (...a) => chain; }, };",
-					"const chain = new Proxy({}, handler);",
-					"module.exports = { z: new Proxy({}, handler) };",
-				].join("\n"),
-			});
-		}
-
-		test("loads emitted JavaScript and exposes the expected runtime exports", async () => {
-			const tempDir = createTempWorkspace("orm-db-golden-");
-			const rendered = renderFixture(CUSTOMER_ORDERS_FIXTURE);
-
-			writeDependencyStubs(tempDir);
-			writeWorkspaceFile({
-				workspacePath: tempDir,
-				relativePath: CODEGEN_EMIT_PATHS.customerOrdersModuleJs,
-				content: rendered.jsCode,
-			});
-
-			const jsPath = join(tempDir, CODEGEN_EMIT_PATHS.customerOrdersModuleJs);
-			const mod = await import(pathToFileURL(jsPath).href);
-
-			expect(typeof mod.CustomerOrders).toBe("function");
-			const client = mod.CustomerOrders("token");
-			expect(client.args).toMatchObject({
-				id: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
-				name: "Customer Orders",
-				auth: "token",
-			});
-			expect(client.args.columns).toBeDefined();
-		});
-	});
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/codegen/database-emitter.test.ts
+++ b/tests/codegen/database-emitter.test.ts
@@ -9,6 +9,7 @@ import { objectKeys } from "../../src/typeUtils";
 import {
 	CODEGEN_EMIT_PATHS,
 	CODEGEN_GOLDEN_FILES,
+	codegenArtifactFileName,
 } from "../helpers/codegen-file-names";
 import {
 	ALL_DATABASE_FIXTURES,
@@ -51,7 +52,10 @@ describe("database module emitter", () => {
 		test("produces TypeScript output that parses successfully", () => {
 			expectCodeToParseAsValidTs({
 				code: rendered.tsCode,
-				fileName: CODEGEN_EMIT_PATHS.customerOrdersModuleTs,
+				fileName: codegenArtifactFileName(
+					CODEGEN_EMIT_PATHS.customerOrdersModule,
+					"typescript",
+				),
 			});
 		});
 	});
@@ -73,7 +77,10 @@ describe("database module emitter", () => {
 		test("produces TypeScript output that parses successfully", () => {
 			expectCodeToParseAsValidTs({
 				code: rendered.tsCode,
-				fileName: CODEGEN_EMIT_PATHS.inventoryItemsModuleTs,
+				fileName: codegenArtifactFileName(
+					CODEGEN_EMIT_PATHS.inventoryItemsModule,
+					"typescript",
+				),
 			});
 		});
 	});
@@ -95,7 +102,10 @@ describe("database module emitter", () => {
 		test("produces TypeScript output that parses successfully", () => {
 			expectCodeToParseAsValidTs({
 				code: rendered.tsCode,
-				fileName: CODEGEN_EMIT_PATHS.edgeCasesModuleTs,
+				fileName: codegenArtifactFileName(
+					CODEGEN_EMIT_PATHS.edgeCasesModule,
+					"typescript",
+				),
 			});
 		});
 

--- a/tests/codegen/generate-databases-cli.e2e.test.ts
+++ b/tests/codegen/generate-databases-cli.e2e.test.ts
@@ -122,7 +122,6 @@ describe("generate-databases-cli e2e orchestration", () => {
 			),
 		).toBe(true);
 		expect(existsSync(AST_FS_PATHS.databaseBarrelTs)).toBe(true);
-		expect(existsSync(AST_FS_PATHS.databaseBarrelJs)).toBe(true);
 	});
 
 	test("incremental generation emits a single db and updates source index when enabled", async () => {
@@ -152,7 +151,6 @@ describe("generate-databases-cli e2e orchestration", () => {
 			),
 		).toBe(true);
 		expect(existsSync(AST_FS_PATHS.buildIndexTs)).toBe(true);
-		expect(existsSync(AST_FS_PATHS.buildIndexJs)).toBe(true);
 		expect(existsSync(AST_FS_PATHS.buildIndexDts)).toBe(true);
 	});
 });

--- a/tests/codegen/generate-databases-cli.e2e.test.ts
+++ b/tests/codegen/generate-databases-cli.e2e.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { readDatabaseMetadata } from "../../src/ast/shared/cached-metadata";
 import { AST_FS_PATHS } from "../../src/ast/shared/constants";
 import { clearConfigCache } from "../../src/config/loadConfig";
+import { inferCodegenEnvironment } from "../../src/ast/shared/codegen-environment";
 import { CODEGEN_EMIT_PATHS } from "../helpers/codegen-file-names";
 import {
 	buildMockDataSourceResponse,
@@ -36,10 +37,11 @@ function writeConfigFile(args: {
 	databases: string[];
 	agents?: string[];
 	auth?: string;
+	configFileName?: "notion.config.ts" | "notion.config.mjs";
 }) {
 	writeWorkspaceFile({
 		workspacePath: args.workspacePath,
-		relativePath: CODEGEN_EMIT_PATHS.notionConfigMjs,
+		relativePath: args.configFileName ?? CODEGEN_EMIT_PATHS.notionConfigMjs,
 		content: [
 			"export default {",
 			`  auth: '${args.auth ?? "token-123"}',`,
@@ -122,6 +124,87 @@ describe("generate-databases-cli e2e orchestration", () => {
 			),
 		).toBe(true);
 		expect(existsSync(AST_FS_PATHS.databaseBarrelTs)).toBe(true);
+	});
+
+	test("typescript projects emit .ts generated modules", async () => {
+		const workspacePath = createTempWorkspace("db-generate-e2e-ts-env-");
+		process.chdir(workspacePath);
+
+		writeConfigFile({
+			workspacePath,
+			databases: [CUSTOMER_ORDERS_FIXTURE.id],
+			configFileName: "notion.config.ts",
+		});
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: "tsconfig.json",
+			content: JSON.stringify(
+				{
+					compilerOptions: {
+						target: "ES2022",
+					},
+				},
+				null,
+				2,
+			),
+		});
+
+		expect(inferCodegenEnvironment({ configRuntime: { isTS: true } })).toBe(
+			"typescript",
+		);
+
+		await createDatabaseTypes({
+			type: "all",
+			skipSourceIndexUpdate: true,
+		});
+
+		expect(
+			existsSync(
+				join(AST_FS_PATHS.DATABASES_DIR, CODEGEN_EMIT_PATHS.customerOrdersModuleTs),
+			),
+		).toBe(true);
+		expect(
+			existsSync(
+				join(AST_FS_PATHS.DATABASES_DIR, CODEGEN_EMIT_PATHS.customerOrdersModuleJs),
+			),
+		).toBe(false);
+		expect(existsSync(AST_FS_PATHS.databaseBarrelTs)).toBe(true);
+		expect(existsSync(AST_FS_PATHS.databaseBarrelJs)).toBe(false);
+		expect(existsSync(AST_FS_PATHS.buildIndexTs)).toBe(true);
+		expect(existsSync(AST_FS_PATHS.buildIndexJs)).toBe(false);
+		expect(existsSync(AST_FS_PATHS.buildIndexDts)).toBe(true);
+	});
+
+	test("javascript projects emit .js generated modules", async () => {
+		const workspacePath = createTempWorkspace("db-generate-e2e-js-env-");
+		process.chdir(workspacePath);
+
+		writeConfigFile({
+			workspacePath,
+			databases: [CUSTOMER_ORDERS_FIXTURE.id],
+			configFileName: "notion.config.mjs",
+		});
+
+		await createDatabaseTypes({
+			type: "all",
+			skipSourceIndexUpdate: false,
+		});
+
+		expect(
+			existsSync(
+				join(AST_FS_PATHS.DATABASES_DIR, CODEGEN_EMIT_PATHS.customerOrdersModuleJs),
+			),
+		).toBe(true);
+		expect(
+			existsSync(
+				join(AST_FS_PATHS.DATABASES_DIR, CODEGEN_EMIT_PATHS.customerOrdersModuleTs),
+			),
+		).toBe(false);
+		expect(existsSync(AST_FS_PATHS.databaseBarrelJs)).toBe(true);
+		expect(existsSync(AST_FS_PATHS.databaseBarrelTs)).toBe(false);
+		expect(existsSync(AST_FS_PATHS.buildIndexJs)).toBe(true);
+		expect(existsSync(AST_FS_PATHS.buildIndexTs)).toBe(false);
+		expect(existsSync(AST_FS_PATHS.buildIndexDts)).toBe(true);
 	});
 
 	test("incremental generation emits a single db and updates source index when enabled", async () => {

--- a/tests/codegen/generate-databases-cli.e2e.test.ts
+++ b/tests/codegen/generate-databases-cli.e2e.test.ts
@@ -2,10 +2,16 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { readDatabaseMetadata } from "../../src/ast/shared/cached-metadata";
-import { AST_FS_PATHS } from "../../src/ast/shared/constants";
+import {
+	AST_FS_PATHS,
+	codegenIndexSourcePath,
+} from "../../src/ast/shared/constants";
 import { clearConfigCache } from "../../src/config/loadConfig";
-import { inferCodegenEnvironment } from "../../src/ast/shared/codegen-environment";
-import { CODEGEN_EMIT_PATHS } from "../helpers/codegen-file-names";
+import { resolveCodegenEnvironment } from "../../src/ast/shared/codegen-environment";
+import {
+	CODEGEN_EMIT_PATHS,
+	codegenArtifactFileName,
+} from "../helpers/codegen-file-names";
 import {
 	buildMockDataSourceResponse,
 	CUSTOMER_ORDERS_FIXTURE,
@@ -37,7 +43,9 @@ function writeConfigFile(args: {
 	databases: string[];
 	agents?: string[];
 	auth?: string;
-	configFileName?: "notion.config.ts" | "notion.config.mjs";
+	configFileName?:
+		| typeof CODEGEN_EMIT_PATHS.notionConfigTs
+		| typeof CODEGEN_EMIT_PATHS.notionConfigMjs;
 }) {
 	writeWorkspaceFile({
 		workspacePath: args.workspacePath,
@@ -71,6 +79,12 @@ describe("generate-databases-cli e2e orchestration", () => {
 		writeConfigFile({
 			workspacePath,
 			databases: [CUSTOMER_ORDERS_FIXTURE.id, INVENTORY_ITEMS_FIXTURE.id],
+			configFileName: CODEGEN_EMIT_PATHS.notionConfigTs,
+		});
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: "tsconfig.json",
+			content: JSON.stringify({ compilerOptions: { target: "ES2022" } }, null, 2),
 		});
 
 		retrieveDataSourceMock.mockImplementation(async (args) => {
@@ -109,21 +123,31 @@ describe("generate-databases-cli e2e orchestration", () => {
 
 		expect(
 			existsSync(
-				join(
-					AST_FS_PATHS.DATABASES_DIR,
-					CODEGEN_EMIT_PATHS.customerOrdersModuleTs,
-				),
+				join(AST_FS_PATHS.DATABASES_DIR, codegenArtifactFileName(
+					CODEGEN_EMIT_PATHS.customerOrdersModule,
+					"typescript",
+				)),
 			),
 		).toBe(true);
 		expect(
 			existsSync(
 				join(
 					AST_FS_PATHS.DATABASES_DIR,
-					CODEGEN_EMIT_PATHS.inventoryItemsModuleTs,
+					codegenArtifactFileName(
+						CODEGEN_EMIT_PATHS.inventoryItemsModule,
+						"typescript",
+					),
 				),
 			),
 		).toBe(true);
-		expect(existsSync(AST_FS_PATHS.databaseBarrelTs)).toBe(true);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "databases",
+					environment: "typescript",
+				}),
+			),
+		).toBe(true);
 	});
 
 	test("typescript projects emit .ts generated modules", async () => {
@@ -133,7 +157,7 @@ describe("generate-databases-cli e2e orchestration", () => {
 		writeConfigFile({
 			workspacePath,
 			databases: [CUSTOMER_ORDERS_FIXTURE.id],
-			configFileName: "notion.config.ts",
+			configFileName: CODEGEN_EMIT_PATHS.notionConfigTs,
 		});
 		writeWorkspaceFile({
 			workspacePath,
@@ -149,29 +173,67 @@ describe("generate-databases-cli e2e orchestration", () => {
 			),
 		});
 
-		expect(inferCodegenEnvironment({ configRuntime: { isTS: true } })).toBe(
+		expect(resolveCodegenEnvironment({ configRuntime: { isTS: true } })).toBe(
 			"typescript",
+		);
+
+		retrieveDataSourceMock.mockImplementation(async () =>
+			buildMockDataSourceResponse(CUSTOMER_ORDERS_FIXTURE),
 		);
 
 		await createDatabaseTypes({
 			type: "all",
-			skipSourceIndexUpdate: true,
+			skipSourceIndexUpdate: false,
 		});
 
 		expect(
 			existsSync(
-				join(AST_FS_PATHS.DATABASES_DIR, CODEGEN_EMIT_PATHS.customerOrdersModuleTs),
+				join(AST_FS_PATHS.DATABASES_DIR, codegenArtifactFileName(
+					CODEGEN_EMIT_PATHS.customerOrdersModule,
+					"typescript",
+				)),
 			),
 		).toBe(true);
 		expect(
 			existsSync(
-				join(AST_FS_PATHS.DATABASES_DIR, CODEGEN_EMIT_PATHS.customerOrdersModuleJs),
+				join(AST_FS_PATHS.DATABASES_DIR, codegenArtifactFileName(
+					CODEGEN_EMIT_PATHS.customerOrdersModule,
+					"javascript",
+				)),
 			),
 		).toBe(false);
-		expect(existsSync(AST_FS_PATHS.databaseBarrelTs)).toBe(true);
-		expect(existsSync(AST_FS_PATHS.databaseBarrelJs)).toBe(false);
-		expect(existsSync(AST_FS_PATHS.buildIndexTs)).toBe(true);
-		expect(existsSync(AST_FS_PATHS.buildIndexJs)).toBe(false);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "databases",
+					environment: "typescript",
+				}),
+			),
+		).toBe(true);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "databases",
+					environment: "javascript",
+				}),
+			),
+		).toBe(false);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "codegenRoot",
+					environment: "typescript",
+				}),
+			),
+		).toBe(true);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "codegenRoot",
+					environment: "javascript",
+				}),
+			),
+		).toBe(false);
 		expect(existsSync(AST_FS_PATHS.buildIndexDts)).toBe(true);
 	});
 
@@ -182,8 +244,12 @@ describe("generate-databases-cli e2e orchestration", () => {
 		writeConfigFile({
 			workspacePath,
 			databases: [CUSTOMER_ORDERS_FIXTURE.id],
-			configFileName: "notion.config.mjs",
+			configFileName: CODEGEN_EMIT_PATHS.notionConfigMjs,
 		});
+
+		retrieveDataSourceMock.mockImplementation(async () =>
+			buildMockDataSourceResponse(CUSTOMER_ORDERS_FIXTURE),
+		);
 
 		await createDatabaseTypes({
 			type: "all",
@@ -192,18 +258,52 @@ describe("generate-databases-cli e2e orchestration", () => {
 
 		expect(
 			existsSync(
-				join(AST_FS_PATHS.DATABASES_DIR, CODEGEN_EMIT_PATHS.customerOrdersModuleJs),
+				join(AST_FS_PATHS.DATABASES_DIR, codegenArtifactFileName(
+					CODEGEN_EMIT_PATHS.customerOrdersModule,
+					"javascript",
+				)),
 			),
 		).toBe(true);
 		expect(
 			existsSync(
-				join(AST_FS_PATHS.DATABASES_DIR, CODEGEN_EMIT_PATHS.customerOrdersModuleTs),
+				join(AST_FS_PATHS.DATABASES_DIR, codegenArtifactFileName(
+					CODEGEN_EMIT_PATHS.customerOrdersModule,
+					"typescript",
+				)),
 			),
 		).toBe(false);
-		expect(existsSync(AST_FS_PATHS.databaseBarrelJs)).toBe(true);
-		expect(existsSync(AST_FS_PATHS.databaseBarrelTs)).toBe(false);
-		expect(existsSync(AST_FS_PATHS.buildIndexJs)).toBe(true);
-		expect(existsSync(AST_FS_PATHS.buildIndexTs)).toBe(false);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "databases",
+					environment: "javascript",
+				}),
+			),
+		).toBe(true);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "databases",
+					environment: "typescript",
+				}),
+			),
+		).toBe(false);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "codegenRoot",
+					environment: "javascript",
+				}),
+			),
+		).toBe(true);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "codegenRoot",
+					environment: "typescript",
+				}),
+			),
+		).toBe(false);
 		expect(existsSync(AST_FS_PATHS.buildIndexDts)).toBe(true);
 	});
 
@@ -214,6 +314,12 @@ describe("generate-databases-cli e2e orchestration", () => {
 		writeConfigFile({
 			workspacePath,
 			databases: [CUSTOMER_ORDERS_FIXTURE.id],
+			configFileName: CODEGEN_EMIT_PATHS.notionConfigTs,
+		});
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: "tsconfig.json",
+			content: JSON.stringify({ compilerOptions: { target: "ES2022" } }, null, 2),
 		});
 
 		retrieveDataSourceMock.mockImplementation(async () =>
@@ -230,10 +336,23 @@ describe("generate-databases-cli e2e orchestration", () => {
 		expect(output.databaseNames).toEqual(["Edge Cases"]);
 		expect(
 			existsSync(
-				join(AST_FS_PATHS.DATABASES_DIR, CODEGEN_EMIT_PATHS.edgeCasesModuleTs),
+				join(
+					AST_FS_PATHS.DATABASES_DIR,
+					codegenArtifactFileName(
+						CODEGEN_EMIT_PATHS.edgeCasesModule,
+						"typescript",
+					),
+				),
 			),
 		).toBe(true);
-		expect(existsSync(AST_FS_PATHS.buildIndexTs)).toBe(true);
+		expect(
+			existsSync(
+				codegenIndexSourcePath({
+					scope: "codegenRoot",
+					environment: "typescript",
+				}),
+			),
+		).toBe(true);
 		expect(existsSync(AST_FS_PATHS.buildIndexDts)).toBe(true);
 	});
 });

--- a/tests/codegen/generated-client-calls.e2e.test.ts
+++ b/tests/codegen/generated-client-calls.e2e.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
 import {
 	buildOrmIndexModuleAst,
@@ -26,6 +27,10 @@ import {
 } from "../helpers/temp-workspace";
 
 const tempDirs: string[] = [];
+
+/** Repo root (for `file:` install of this package in temp consumers). */
+const ORM_REPO_ROOT = fileURLToPath(new URL("../../", import.meta.url));
+const ORM_REPO_FILE_URL = pathToFileURL(ORM_REPO_ROOT).href;
 
 describe("generated consumer install compatibility", () => {
 	test("generated TypeScript resolves package exports in a consumer-style typecheck", () => {
@@ -68,7 +73,7 @@ describe("generated consumer install compatibility", () => {
 						private: true,
 						type: "module",
 						dependencies: {
-							"@haustle/notion-orm": "file:/workspace",
+							"@haustle/notion-orm": ORM_REPO_FILE_URL,
 						},
 						devDependencies: {
 							typescript: "^5.6.3",

--- a/tests/codegen/generated-client-calls.e2e.test.ts
+++ b/tests/codegen/generated-client-calls.e2e.test.ts
@@ -4,8 +4,15 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { buildOrmIndexModuleAst } from "../../src/ast/shared/emit/orm-index-emitter";
-import { createEmitContext, printTsNodes } from "../../src/ast/shared/emit/ts-emit-core";
+import {
+	buildOrmIndexModuleAst,
+	emitOrmIndexArtifacts,
+} from "../../src/ast/shared/emit/orm-index-emitter";
+import {
+	createEmitContext,
+	printTsNodes,
+	transpileTsToJs,
+} from "../../src/ast/shared/emit/ts-emit-core";
 import { AST_RUNTIME_CONSTANTS } from "../../src/ast/shared/constants";
 import { renderDatabaseModule } from "../../src/ast/database/database-file-writer";
 import {
@@ -63,9 +70,9 @@ describe("generated consumer install compatibility", () => {
 						dependencies: {
 							"@haustle/notion-orm": "file:/workspace",
 						},
-					devDependencies: {
-						typescript: "^5.6.3",
-					},
+						devDependencies: {
+							typescript: "^5.6.3",
+						},
 					},
 					null,
 					2,
@@ -142,5 +149,30 @@ describe("generated consumer install compatibility", () => {
 				rmSync(tempDir, { recursive: true, force: true });
 			}
 		}
+	});
+
+	test("generated JavaScript output can be imported directly in a JS consumer", () => {
+		const renderedDatabase = renderDatabaseModule(
+			buildMockDataSourceResponse(CUSTOMER_ORDERS_FIXTURE),
+		);
+		const databaseJs = transpileTsToJs({
+			typescriptCode: renderedDatabase.tsCode,
+		});
+		assert.match(databaseJs, /from "@haustle\/notion-orm"/);
+
+		const tempOutputDir = mkdtempSync(join(tmpdir(), "orm-generated-js-"));
+		tempDirs.push(tempOutputDir);
+		const emittedIndexPath = join(tempOutputDir, "index.js");
+		const emittedDtsPath = join(tempOutputDir, "index.d.ts");
+		const { code } = emitOrmIndexArtifacts({
+			databases: [{ name: renderedDatabase.databaseModuleName }],
+			agents: [],
+			buildIndexPath: emittedIndexPath,
+			buildIndexDtsPath: emittedDtsPath,
+			syncCommand: AST_RUNTIME_CONSTANTS.CLI_GENERATE_COMMAND,
+			environment: "javascript",
+		});
+		assert.match(code, /\.\/databases\/CustomerOrders\.js/);
+		assert.match(code, /from "@haustle\/notion-orm\/base"/);
 	});
 });

--- a/tests/codegen/generated-client-calls.e2e.test.ts
+++ b/tests/codegen/generated-client-calls.e2e.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -19,116 +20,127 @@ import {
 
 const tempDirs: string[] = [];
 
-afterEach(() => {
-	cleanupTempWorkspaces();
-	while (tempDirs.length > 0) {
-		const tempDir = tempDirs.pop();
-		if (!tempDir) {
-			continue;
-		}
-		rmSync(tempDir, { recursive: true, force: true });
-	}
-});
-
 describe("generated consumer install compatibility", () => {
 	test("generated TypeScript resolves package exports in a consumer-style typecheck", () => {
-		const renderedDatabase = renderDatabaseModule(
-			buildMockDataSourceResponse(CUSTOMER_ORDERS_FIXTURE),
-		);
-		expect(renderedDatabase.tsCode).toContain('from "@haustle/notion-orm"');
+		try {
+			const renderedDatabase = renderDatabaseModule(
+				buildMockDataSourceResponse(CUSTOMER_ORDERS_FIXTURE),
+			);
+			assert.match(renderedDatabase.tsCode, /from "@haustle\/notion-orm"/);
 
-		const notionWorkspace = createTempWorkspace("generated-consumer-notion-");
-		writeWorkspaceFile({
-			workspacePath: notionWorkspace,
-			relativePath: "notion/databases/CustomerOrders.ts",
-			content: renderedDatabase.tsCode,
-		});
+			const notionWorkspace = createTempWorkspace("generated-consumer-notion-");
+			writeWorkspaceFile({
+				workspacePath: notionWorkspace,
+				relativePath: "notion/databases/CustomerOrders.ts",
+				content: renderedDatabase.tsCode,
+			});
 
-		const generatedIndexTs = printTsNodes({
-			nodes: buildOrmIndexModuleAst({
-				databases: [{ name: renderedDatabase.databaseModuleName }],
-				agents: [],
-				syncCommand: AST_RUNTIME_CONSTANTS.CLI_GENERATE_COMMAND,
-			}),
-			context: createEmitContext({ fileName: "index.ts" }),
-		});
-		writeWorkspaceFile({
-			workspacePath: notionWorkspace,
-			relativePath: "notion/index.ts",
-			content: generatedIndexTs,
-		});
+			const generatedIndexTs = printTsNodes({
+				nodes: buildOrmIndexModuleAst({
+					databases: [{ name: renderedDatabase.databaseModuleName }],
+					agents: [],
+					syncCommand: AST_RUNTIME_CONSTANTS.CLI_GENERATE_COMMAND,
+				}),
+				context: createEmitContext({ fileName: "index.ts" }),
+			});
+			writeWorkspaceFile({
+				workspacePath: notionWorkspace,
+				relativePath: "notion/index.ts",
+				content: generatedIndexTs,
+			});
 
-		const consumerPath = mkdtempSync(join(tmpdir(), "orm-consumer-typecheck-"));
-		tempDirs.push(consumerPath);
-		writeFileSync(
-			join(consumerPath, "package.json"),
-			JSON.stringify(
-				{
-					name: "orm-consumer-typecheck",
-					private: true,
-					type: "module",
-					dependencies: {
-						"@haustle/notion-orm": "file:/workspace",
+			const consumerPath = mkdtempSync(
+				join(tmpdir(), "orm-consumer-typecheck-"),
+			);
+			tempDirs.push(consumerPath);
+			writeFileSync(
+				join(consumerPath, "package.json"),
+				JSON.stringify(
+					{
+						name: "orm-consumer-typecheck",
+						private: true,
+						type: "module",
+						dependencies: {
+							"@haustle/notion-orm": "file:/workspace",
+						},
+					devDependencies: {
+						typescript: "^5.6.3",
 					},
-				},
-				null,
-				2,
-			),
-		);
-		writeFileSync(
-			join(consumerPath, "tsconfig.json"),
-			JSON.stringify(
-				{
-					compilerOptions: {
-						target: "ES2022",
-						module: "NodeNext",
-						moduleResolution: "NodeNext",
-						strict: true,
-						noEmit: true,
-						esModuleInterop: true,
-						skipLibCheck: true,
 					},
-					include: ["src", "notion"],
-				},
-				null,
-				2,
-			),
-		);
-		writeWorkspaceFile({
-			workspacePath: consumerPath,
-			relativePath: "src/app.ts",
-			[
-				'import { NotionORM } from "../notion/index.js";',
-				"const notion = new NotionORM({ auth: \"token\" });",
-				"void notion.databases.customerOrders;",
-				"",
-			].join("\n"),
-		});
-		writeWorkspaceFile({
-			workspacePath: consumerPath,
-			relativePath: "notion/index.ts",
-			content: generatedIndexTs,
-		});
-		writeWorkspaceFile({
-			workspacePath: consumerPath,
-			relativePath: "notion/databases/CustomerOrders.ts",
-			content: renderedDatabase.tsCode,
-		});
+					null,
+					2,
+				),
+			);
+			writeFileSync(
+				join(consumerPath, "tsconfig.json"),
+				JSON.stringify(
+					{
+						compilerOptions: {
+							target: "ES2022",
+							module: "NodeNext",
+							moduleResolution: "NodeNext",
+							strict: true,
+							noEmit: true,
+							esModuleInterop: true,
+							skipLibCheck: true,
+						},
+						include: ["src", "notion"],
+					},
+					null,
+					2,
+				),
+			);
+			writeWorkspaceFile({
+				workspacePath: consumerPath,
+				relativePath: "src/app.ts",
+				content: [
+					'import { NotionORM } from "../notion/index.js";',
+					'const notion = new NotionORM({ auth: "token" });',
+					"void notion.databases.customerOrders;",
+					"",
+				].join("\n"),
+			});
+			writeWorkspaceFile({
+				workspacePath: consumerPath,
+				relativePath: "notion/index.ts",
+				content: generatedIndexTs,
+			});
+			writeWorkspaceFile({
+				workspacePath: consumerPath,
+				relativePath: "notion/databases/CustomerOrders.ts",
+				content: renderedDatabase.tsCode,
+			});
 
-		const install = spawnSync("npm", ["install", "--ignore-scripts"], {
-			cwd: consumerPath,
-			encoding: "utf-8",
-		});
-		expect(install.status).toBe(0);
-
-		const typecheck = spawnSync(
-			"npx",
-			["tsc", "--noEmit", "-p", "tsconfig.json"],
-			{
+			const install = spawnSync("npm", ["install", "--ignore-scripts"], {
 				cwd: consumerPath,
 				encoding: "utf-8",
-			},
-		);
-		expect(typecheck.status).toBe(0);
+			});
+			assert.equal(install.status, 0, install.stderr || install.stdout);
+
+			const typecheck = spawnSync(
+				process.platform === "win32"
+					? join(consumerPath, "node_modules", ".bin", "tsc.cmd")
+					: join(consumerPath, "node_modules", ".bin", "tsc"),
+				["--noEmit", "-p", "tsconfig.json"],
+				{
+					cwd: consumerPath,
+					encoding: "utf-8",
+				},
+			);
+			assert.equal(
+				typecheck.status,
+				0,
+				typecheck.stderr || typecheck.stdout,
+			);
+		} finally {
+			cleanupTempWorkspaces();
+			while (tempDirs.length > 0) {
+				const tempDir = tempDirs.pop();
+				if (!tempDir) {
+					continue;
+				}
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		}
 	});
 });

--- a/tests/codegen/generated-client-calls.e2e.test.ts
+++ b/tests/codegen/generated-client-calls.e2e.test.ts
@@ -1,166 +1,134 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
-import type {
-	CreatePageParameters,
-	QueryDataSourceParameters,
-} from "@notionhq/client/build/src/api-endpoints";
+import { spawnSync } from "node:child_process";
+import { buildOrmIndexModuleAst } from "../../src/ast/shared/emit/orm-index-emitter";
+import { createEmitContext, printTsNodes } from "../../src/ast/shared/emit/ts-emit-core";
+import { AST_RUNTIME_CONSTANTS } from "../../src/ast/shared/constants";
 import { renderDatabaseModule } from "../../src/ast/database/database-file-writer";
-import {
-	CODEGEN_EMIT_PATHS,
-	CODEGEN_TEST_PATHS,
-} from "../helpers/codegen-file-names";
 import {
 	buildMockDataSourceResponse,
 	CUSTOMER_ORDERS_FIXTURE,
 } from "../helpers/datasource-fixture-builder";
-import {
-	installPrismaApiNotionClientMock,
-	prismaApiStubPartialPage,
-	type PrismaApiPagesCreateFn,
-} from "../helpers/notion-client-test-mock";
-import { queryDataSourceListResponse } from "../helpers/query-data-source-response";
-import { databasePropertyValue } from "../helpers/query-transform-fixtures";
 import {
 	cleanupTempWorkspaces,
 	createTempWorkspace,
 	writeWorkspaceFile,
 } from "../helpers/temp-workspace";
 
-const dataSourceQueryMock = mock(async (_call: QueryDataSourceParameters) =>
-	queryDataSourceListResponse([
-		{
-			object: "page",
-			id: "page-order-44",
-			properties: {
-				"Order Name": databasePropertyValue.title("Order #44"),
-				Notes: databasePropertyValue.richText("fragile"),
-				Total: databasePropertyValue.number(42),
-				"Order Date": databasePropertyValue.date("2026-03-01"),
-				Paid: databasePropertyValue.checkbox(true),
-				"Customer Email": databasePropertyValue.email("buyer@example.com"),
-				"Customer Phone": databasePropertyValue.phoneNumber("+1 555 111 1111"),
-				"Receipt URL": databasePropertyValue.url("https://receipt.dev/44"),
-			},
-		},
-	]),
-);
-
-const pagesCreateMock = mock<PrismaApiPagesCreateFn>(async (_call) =>
-	prismaApiStubPartialPage("created-page-id"),
-);
-
-installPrismaApiNotionClientMock({ dataSourceQueryMock, pagesCreateMock });
+const tempDirs: string[] = [];
 
 afterEach(() => {
-	dataSourceQueryMock.mockReset();
-	pagesCreateMock.mockReset();
 	cleanupTempWorkspaces();
+	while (tempDirs.length > 0) {
+		const tempDir = tempDirs.pop();
+		if (!tempDir) {
+			continue;
+		}
+		rmSync(tempDir, { recursive: true, force: true });
+	}
 });
 
-describe("generated database client e2e calls", () => {
-	test("generated customerOrders factory builds valid create/findMany call bodies", async () => {
-		const rendered = renderDatabaseModule(
+describe("generated consumer install compatibility", () => {
+	test("generated TypeScript resolves package exports in a consumer-style typecheck", () => {
+		const renderedDatabase = renderDatabaseModule(
 			buildMockDataSourceResponse(CUSTOMER_ORDERS_FIXTURE),
 		);
-		expect(rendered.jsCode).not.toContain("rollup");
-		const workspacePath = createTempWorkspace("generated-client-calls-");
-		const databaseClientSourcePath = join(
-			process.cwd(),
-			"src/client/database/DatabaseClient.ts",
-		);
-		const zodSourcePath = join(process.cwd(), "node_modules/zod");
+		expect(renderedDatabase.tsCode).toContain('from "@haustle/notion-orm"');
 
+		const notionWorkspace = createTempWorkspace("generated-consumer-notion-");
 		writeWorkspaceFile({
-			workspacePath,
-			relativePath: CODEGEN_EMIT_PATHS.customerOrdersModuleJs,
-			content: rendered.jsCode,
+			workspacePath: notionWorkspace,
+			relativePath: "notion/databases/CustomerOrders.ts",
+			content: renderedDatabase.tsCode,
+		});
+
+		const generatedIndexTs = printTsNodes({
+			nodes: buildOrmIndexModuleAst({
+				databases: [{ name: renderedDatabase.databaseModuleName }],
+				agents: [],
+				syncCommand: AST_RUNTIME_CONSTANTS.CLI_GENERATE_COMMAND,
+			}),
+			context: createEmitContext({ fileName: "index.ts" }),
 		});
 		writeWorkspaceFile({
-			workspacePath,
-			relativePath: CODEGEN_TEST_PATHS.notionOrmModuleIndexJs,
-			content: `module.exports = require(${JSON.stringify(databaseClientSourcePath)});`,
-		});
-		writeWorkspaceFile({
-			workspacePath,
-			relativePath: CODEGEN_TEST_PATHS.zodModuleIndexJs,
-			content: `module.exports = require(${JSON.stringify(zodSourcePath)});`,
+			workspacePath: notionWorkspace,
+			relativePath: "notion/index.ts",
+			content: generatedIndexTs,
 		});
 
-		const mod = await import(
-			pathToFileURL(
-				join(workspacePath, CODEGEN_EMIT_PATHS.customerOrdersModuleJs),
-			).href
-		);
-		const dbClient = mod.CustomerOrders("token-123");
-
-		await dbClient.create({
-			properties: {
-				orderName: "Order #44",
-				notes: "fragile",
-				total: 42,
-				orderDate: { start: "2026-03-01" },
-				paid: true,
-				customerEmail: "buyer@example.com",
-				customerPhone: "+1 555 111 1111",
-				receiptUrl: "https://receipt.dev/44",
-			},
-		});
-		await dbClient.findMany({
-			where: {
-				total: { greater_than: 10 },
-			},
-			sortBy: [{ property: "total", direction: "ascending" }],
-		});
-
-		expect(pagesCreateMock).toHaveBeenCalledTimes(1);
-		expect(dataSourceQueryMock).toHaveBeenCalledTimes(1);
-
-		const createCall = pagesCreateMock.mock.calls[0]?.[0];
-		const queryCall = dataSourceQueryMock.mock.calls[0]?.[0];
-
-		const createCallContract: CreatePageParameters = createCall;
-		const queryCallContract: QueryDataSourceParameters = queryCall;
-		expect(createCallContract.parent.type).toBe("data_source_id");
-		expect(queryCallContract.data_source_id).toBe(
-			"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
-		);
-
-		expect(createCallContract.properties).toEqual({
-			"Order Name": {
-				title: [
-					{
-						text: {
-							content: "Order #44",
-						},
+		const consumerPath = mkdtempSync(join(tmpdir(), "orm-consumer-typecheck-"));
+		tempDirs.push(consumerPath);
+		writeFileSync(
+			join(consumerPath, "package.json"),
+			JSON.stringify(
+				{
+					name: "orm-consumer-typecheck",
+					private: true,
+					type: "module",
+					dependencies: {
+						"@haustle/notion-orm": "file:/workspace",
 					},
-				],
-			},
-			Notes: {
-				rich_text: [
-					{
-						text: {
-							content: "fragile",
-						},
-					},
-				],
-			},
-			Total: { number: 42 },
-			"Order Date": { date: { start: "2026-03-01" } },
-			Paid: { checkbox: true },
-			"Customer Email": { email: "buyer@example.com" },
-			"Customer Phone": { phone_number: "+1 555 111 1111" },
-			"Receipt URL": { url: "https://receipt.dev/44" },
-		});
-		expect(queryCallContract).toEqual({
-			data_source_id: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
-			sorts: [{ property: "Total", direction: "ascending" }],
-			filter: {
-				property: "Total",
-				number: {
-					greater_than: 10,
 				},
-			},
+				null,
+				2,
+			),
+		);
+		writeFileSync(
+			join(consumerPath, "tsconfig.json"),
+			JSON.stringify(
+				{
+					compilerOptions: {
+						target: "ES2022",
+						module: "NodeNext",
+						moduleResolution: "NodeNext",
+						strict: true,
+						noEmit: true,
+						esModuleInterop: true,
+						skipLibCheck: true,
+					},
+					include: ["src", "notion"],
+				},
+				null,
+				2,
+			),
+		);
+		writeWorkspaceFile({
+			workspacePath: consumerPath,
+			relativePath: "src/app.ts",
+			[
+				'import { NotionORM } from "../notion/index.js";',
+				"const notion = new NotionORM({ auth: \"token\" });",
+				"void notion.databases.customerOrders;",
+				"",
+			].join("\n"),
 		});
+		writeWorkspaceFile({
+			workspacePath: consumerPath,
+			relativePath: "notion/index.ts",
+			content: generatedIndexTs,
+		});
+		writeWorkspaceFile({
+			workspacePath: consumerPath,
+			relativePath: "notion/databases/CustomerOrders.ts",
+			content: renderedDatabase.tsCode,
+		});
+
+		const install = spawnSync("npm", ["install", "--ignore-scripts"], {
+			cwd: consumerPath,
+			encoding: "utf-8",
+		});
+		expect(install.status).toBe(0);
+
+		const typecheck = spawnSync(
+			"npx",
+			["tsc", "--noEmit", "-p", "tsconfig.json"],
+			{
+				cwd: consumerPath,
+				encoding: "utf-8",
+			},
+		);
+		expect(typecheck.status).toBe(0);
 	});
 });

--- a/tests/codegen/orm-index-emitter.test.ts
+++ b/tests/codegen/orm-index-emitter.test.ts
@@ -1,12 +1,8 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { describe, expect, test } from "bun:test";
 import * as ts from "typescript";
-import { pathToFileURL } from "url";
 import {
 	buildOrmIndexDeclarationAst,
 	buildOrmIndexModuleAst,
-	emitOrmIndexArtifacts,
 	type OrmEntityMetadata,
 } from "../../src/ast/shared/emit/orm-index-emitter";
 import {
@@ -22,10 +18,6 @@ import {
 	expectNormalizedCodeToMatch,
 	readGolden,
 } from "../helpers/golden-code-assertions";
-import {
-	cleanupTempWorkspaces,
-	createTempWorkspace,
-} from "../helpers/temp-workspace";
 
 const metadata: {
 	databases: OrmEntityMetadata[];
@@ -50,10 +42,6 @@ function isRuntimeNotionOrmConstructor(
 	return typeof value === "function";
 }
 
-afterEach(() => {
-	cleanupTempWorkspaces();
-});
-
 describe("orm index emitter", () => {
 	test("emits declaration source that matches the orm-index golden file", () => {
 		const nodes = buildOrmIndexDeclarationAst(metadata);
@@ -73,64 +61,5 @@ describe("orm index emitter", () => {
 		const classDeclaration = nodes.find((node) => ts.isClassDeclaration(node));
 		expect(classDeclaration).toBeDefined();
 		expect(classDeclaration?.kind).toBe(ts.SyntaxKind.ClassDeclaration);
-	});
-
-	test("emits runtime index that executes and wires databases/agents", async () => {
-		const tempDirectory = createTempWorkspace("orm-index-");
-		const dbDirectory = join(tempDirectory, CODEGEN_EMIT_PATHS.databasesDir);
-		const agentsDirectory = join(tempDirectory, CODEGEN_EMIT_PATHS.agentsDir);
-		mkdirSync(dbDirectory, { recursive: true });
-		mkdirSync(agentsDirectory, { recursive: true });
-
-		const baseStub = [
-			"export class AgentClient {}",
-			"export class DatabaseClient {}",
-			"export class NotionORMBase {",
-			"  constructor(config) {",
-			"    this.notionAuth = config.auth ?? \"\";",
-			"  }",
-			"}",
-			"",
-		].join("\n");
-		const packageBaseDir = join(
-			tempDirectory,
-			"node_modules/@haustle/notion-orm/build/src",
-		);
-		mkdirSync(packageBaseDir, { recursive: true });
-		writeFileSync(join(packageBaseDir, "base.js"), baseStub);
-		writeFileSync(
-			join(dbDirectory, CODEGEN_EMIT_PATHS.taskDbModuleJs),
-			'export const TaskDb = (auth) => ({ kind: "db", auth });\n',
-		);
-		writeFileSync(
-			join(agentsDirectory, CODEGEN_EMIT_PATHS.mealAgentModuleJs),
-			'export const MealAgent = (auth) => ({ kind: "agent", auth });\n',
-		);
-
-		const buildIndexTsPath = join(tempDirectory, CODEGEN_EMIT_PATHS.indexTs);
-		const buildIndexJsPath = join(tempDirectory, CODEGEN_EMIT_PATHS.indexJs);
-		const buildIndexDtsPath = join(tempDirectory, CODEGEN_EMIT_PATHS.indexDts);
-		emitOrmIndexArtifacts({
-			...metadata,
-			buildIndexTsPath,
-			buildIndexJsPath,
-			buildIndexDtsPath,
-			syncCommand: "notion sync",
-		});
-
-		const importedModule = await import(pathToFileURL(buildIndexJsPath).href);
-		if (!isRuntimeNotionOrmConstructor(importedModule.NotionORM)) {
-			throw new Error("Expected emitted module named export NotionORM to be a class");
-		}
-		const { NotionORM } = importedModule;
-		const client = new NotionORM({ auth: "token-123" });
-
-		expect(client.databases.taskDb.kind).toBe("db");
-		expect(client.databases.taskDb.auth).toBe("token-123");
-		expect(client.agents.mealAgent.kind).toBe("agent");
-		expect(client.agents.mealAgent.auth).toBe("token-123");
-
-		const declarationCode = readFileSync(buildIndexDtsPath, "utf-8");
-		expect(declarationCode.includes("class NotionORM")).toBe(true);
 	});
 });

--- a/tests/codegen/registry-emitter.test.ts
+++ b/tests/codegen/registry-emitter.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import * as ts from "typescript";
 import {
 	buildRegistryModuleAst,
@@ -18,8 +21,6 @@ import {
 	expectNormalizedCodeToMatch,
 	readGolden,
 } from "../helpers/golden-code-assertions";
-import {
-} from "../helpers/temp-workspace";
 
 describe("registry emitter", () => {
 	const registryEntries: RegistryEntry[] = [...REGISTRY_SCENARIO.entries];
@@ -54,12 +55,19 @@ describe("registry emitter", () => {
 	});
 
 	test("emits only the TypeScript registry artifact", () => {
-		const tempDirectory = "/tmp/registry-emitter-unused";
-		const indexTsPath = `${tempDirectory}/${CODEGEN_EMIT_PATHS.indexTs}`;
-		emitRegistryModuleArtifacts({
-			registryName: REGISTRY_SCENARIO.registryName,
-			entries: registryEntries,
-			tsPath: indexTsPath,
-		});
+		const tempDirectory = mkdtempSync(join(tmpdir(), "registry-emitter-ts-"));
+		try {
+			const indexTsPath = join(tempDirectory, CODEGEN_EMIT_PATHS.indexTs);
+			const { sourceCode } = emitRegistryModuleArtifacts({
+				registryName: REGISTRY_SCENARIO.registryName,
+				entries: registryEntries,
+				outputPath: indexTsPath,
+				environment: "typescript",
+			});
+			expect(existsSync(indexTsPath)).toBe(true);
+			expect(readFileSync(indexTsPath, "utf8")).toBe(sourceCode);
+		} finally {
+			rmSync(tempDirectory, { recursive: true, force: true });
+		}
 	});
 });

--- a/tests/codegen/registry-emitter.test.ts
+++ b/tests/codegen/registry-emitter.test.ts
@@ -1,8 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { writeFileSync } from "fs";
-import { join } from "path";
+import { describe, expect, test } from "bun:test";
 import * as ts from "typescript";
-import { pathToFileURL } from "url";
 import {
 	buildRegistryModuleAst,
 	emitRegistryModuleArtifacts,
@@ -22,48 +19,10 @@ import {
 	readGolden,
 } from "../helpers/golden-code-assertions";
 import {
-	cleanupTempWorkspaces,
-	createTempWorkspace,
 } from "../helpers/temp-workspace";
-
-afterEach(() => {
-	cleanupTempWorkspaces();
-});
 
 describe("registry emitter", () => {
 	const registryEntries: RegistryEntry[] = [...REGISTRY_SCENARIO.entries];
-
-	function createRuntimeModuleSource(args: {
-		exportName: string;
-		id: string;
-	}): string {
-		return `export const ${args.exportName} = { id: ${JSON.stringify(args.id)} };\n`;
-	}
-
-	function writeRuntimeRegistryModules(tempDirectory: string): void {
-		const runtimeModules = [
-			{
-				fileName: CODEGEN_EMIT_PATHS.inventoryItemsModuleJs,
-				exportName: "InventoryItems",
-				id: "inventory-items",
-			},
-			{
-				fileName: CODEGEN_EMIT_PATHS.customerOrdersModuleJs,
-				exportName: "CustomerOrders",
-				id: "customer-orders",
-			},
-		] as const;
-
-		for (const moduleDef of runtimeModules) {
-			writeFileSync(
-				join(tempDirectory, moduleDef.fileName),
-				createRuntimeModuleSource({
-					exportName: moduleDef.exportName,
-					id: moduleDef.id,
-				}),
-			);
-		}
-	}
 
 	// A registry is an exported object that maps keys to imported modules.
 	// Checks generated TypeScript matches the expected registry source exactly.
@@ -94,25 +53,13 @@ describe("registry emitter", () => {
 		expect(nodes[1].kind).toBe(ts.SyntaxKind.VariableStatement);
 	});
 
-	// Checks generated JavaScript exports a working registry object at runtime.
-	test("emits JavaScript registry that can be imported at runtime", async () => {
-		const tempDirectory = createTempWorkspace("orm-registry-");
-		writeRuntimeRegistryModules(tempDirectory);
-
-		const indexTsPath = join(tempDirectory, CODEGEN_EMIT_PATHS.indexTs);
-		const indexJsPath = join(tempDirectory, CODEGEN_EMIT_PATHS.indexJs);
-		// emitRegistryModuleArtifacts arguments:
-		// - registryName/entries: define exported registry shape
-		// - tsPath/jsPath: target artifact file locations
+	test("emits only the TypeScript registry artifact", () => {
+		const tempDirectory = "/tmp/registry-emitter-unused";
+		const indexTsPath = `${tempDirectory}/${CODEGEN_EMIT_PATHS.indexTs}`;
 		emitRegistryModuleArtifacts({
 			registryName: REGISTRY_SCENARIO.registryName,
 			entries: registryEntries,
 			tsPath: indexTsPath,
-			jsPath: indexJsPath,
 		});
-
-		const importedModule = await import(pathToFileURL(indexJsPath).href);
-		expect(importedModule.items.inventoryItems.id).toBe("inventory-items");
-		expect(importedModule.items.customerOrders.id).toBe("customer-orders");
 	});
 });

--- a/tests/golden/orm-index.d.ts
+++ b/tests/golden/orm-index.d.ts
@@ -8,9 +8,9 @@ import type { TaskDb } from "./databases/TaskDb";
 import type { MealAgent } from "./agents/MealAgent";
 
 // Package imports: NotionORMBase, config types, and client classes.
-import { NotionORMBase, AgentClient, DatabaseClient } from "@haustle/notion-orm/build/src/base";
-export type { NotionConfigType } from "@haustle/notion-orm/build/src/base";
-export { AgentClient, DatabaseClient } from "@haustle/notion-orm/build/src/base";
+import { NotionORMBase, AgentClient, DatabaseClient } from "@haustle/notion-orm/base";
+export type { NotionConfigType } from "@haustle/notion-orm/base";
+export { AgentClient, DatabaseClient } from "@haustle/notion-orm/base";
 
 /**
  * Generated Notion ORM entrypoint for this project.

--- a/tests/golden/orm-index.d.ts
+++ b/tests/golden/orm-index.d.ts
@@ -2,10 +2,10 @@
 // Regenerate with `notion sync` (or your package script).
 // Database client factories (generated under ./databases/).
 
-import type { TaskDb } from "./databases/TaskDb";
+import type { TaskDb } from "./databases/TaskDb.js";
 
 // Agent client factories (generated under ./agents/).
-import type { MealAgent } from "./agents/MealAgent";
+import type { MealAgent } from "./agents/MealAgent.js";
 
 // Package imports: NotionORMBase, config types, and client classes.
 import { NotionORMBase, AgentClient, DatabaseClient } from "@haustle/notion-orm/base";

--- a/tests/helpers/codegen-file-names.ts
+++ b/tests/helpers/codegen-file-names.ts
@@ -4,36 +4,34 @@ export const CODEGEN_GOLDEN_FILES = {
 	ormIndexDeclaration: "orm-index.d.ts",
 
 	dbCustomerOrdersTs: "databases/CustomerOrders.ts",
-	dbCustomerOrdersJs: "databases/CustomerOrders.js",
 	dbInventoryItemsTs: "databases/InventoryItems.ts",
-	dbInventoryItemsJs: "databases/InventoryItems.js",
 	dbEdgeCasesTs: "databases/EdgeCases.ts",
-	dbEdgeCasesJs: "databases/EdgeCases.js",
 } as const;
 
 export const CODEGEN_EMIT_PATHS = {
 	indexTs: "index.ts",
-	indexJs: "index.js",
 	indexDts: "index.d.ts",
 	notionConfigTs: "notion.config.ts",
 	notionConfigMjs: "notion.config.mjs",
 	databasesDir: "databases",
 	agentsDir: "agents",
-	baseModuleJs: "base.js",
-	taskDbModuleJs: "TaskDb.js",
-	mealAgentModuleJs: "MealAgent.js",
 	customerOrdersModuleTs: "CustomerOrders.ts",
 	inventoryItemsModuleTs: "InventoryItems.ts",
 	edgeCasesModuleTs: "EdgeCases.ts",
-	inventoryItemsModuleJs: "InventoryItems.js",
-	customerOrdersModuleJs: "CustomerOrders.js",
-	edgeCasesModuleJs: "EdgeCases.js",
+	taskDbModuleTs: "TaskDb.ts",
+	mealAgentModuleTs: "MealAgent.ts",
 } as const;
 
 export const CODEGEN_TEST_PATHS = {
 	goldenDir: "golden",
+	notionOrmPackageJson: "node_modules/@haustle/notion-orm/package.json",
+	notionOrmModuleIndexDts: "node_modules/@haustle/notion-orm/index.d.ts",
 	notionOrmModuleIndexJs: "node_modules/@haustle/notion-orm/index.js",
+	notionOrmBaseDts: "node_modules/@haustle/notion-orm/base.d.ts",
+	notionOrmBaseJs: "node_modules/@haustle/notion-orm/base.js",
+	zodModuleIndexDts: "node_modules/zod/index.d.ts",
 	zodModuleIndexJs: "node_modules/zod/index.js",
+	zodPackageJson: "node_modules/zod/package.json",
 } as const;
 
 export const CODEGEN_PARSE_VIRTUAL_FILENAMES = {

--- a/tests/helpers/codegen-file-names.ts
+++ b/tests/helpers/codegen-file-names.ts
@@ -1,3 +1,11 @@
+import { NOTION_CONFIG_FILENAMES } from "../../src/config/notion-config-filenames";
+
+/** Re-export for tests that compose env-specific artifact names. */
+export {
+	codegenArtifactFileName,
+	type CodegenEnvironment,
+} from "../../src/ast/shared/codegen-environment";
+
 export const CODEGEN_GOLDEN_FILES = {
 	registryItems: "registry-items.ts",
 	configTemplate: "notion-config-template.ts",
@@ -11,15 +19,17 @@ export const CODEGEN_GOLDEN_FILES = {
 export const CODEGEN_EMIT_PATHS = {
 	indexTs: "index.ts",
 	indexDts: "index.d.ts",
-	notionConfigTs: "notion.config.ts",
-	notionConfigMjs: "notion.config.mjs",
+	notionConfigTs: NOTION_CONFIG_FILENAMES.ts,
+	notionConfigMjs: NOTION_CONFIG_FILENAMES.mjs,
 	databasesDir: "databases",
 	agentsDir: "agents",
-	customerOrdersModuleTs: "CustomerOrders.ts",
-	inventoryItemsModuleTs: "InventoryItems.ts",
-	edgeCasesModuleTs: "EdgeCases.ts",
-	taskDbModuleTs: "TaskDb.ts",
-	mealAgentModuleTs: "MealAgent.ts",
+	/**
+	 * PascalCase basenames for generated DB/agent modules in tests.
+	 * Build filenames with {@link codegenArtifactFileName}(basename, env).
+	 */
+	customerOrdersModule: "CustomerOrders",
+	inventoryItemsModule: "InventoryItems",
+	edgeCasesModule: "EdgeCases",
 } as const;
 
 export const CODEGEN_TEST_PATHS = {

--- a/tests/helpers/query-transform-fixtures.ts
+++ b/tests/helpers/query-transform-fixtures.ts
@@ -11,6 +11,7 @@ import { buildQueryResponse } from "../../src/client/database/query";
 import type { NotionPropertyValue } from "../../src/client/database/query/types";
 import type {
 	DatabaseColumns,
+	DatabasePropertyValue,
 	QueryResponseWithoutRawResponse,
 	QueryResponseWithRawResponse,
 	SupportedNotionColumnType,
@@ -65,7 +66,7 @@ type SupportedTypeToHelperMethodName = {
  * by the runtime query pipeline, with optional raw-response passthrough.
  */
 export function runQueryScenario<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 >(
 	args: ReturnType<typeof buildQueryScenario>,
 	options: {
@@ -74,7 +75,7 @@ export function runQueryScenario<
 	},
 ): QueryResponseWithRawResponse<DatabaseSchemaType>;
 export function runQueryScenario<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 >(
 	args: ReturnType<typeof buildQueryScenario>,
 	options?: {
@@ -83,7 +84,7 @@ export function runQueryScenario<
 	},
 ): QueryResponseWithoutRawResponse<DatabaseSchemaType>;
 export function runQueryScenario<
-	DatabaseSchemaType extends Record<string, unknown>,
+	DatabaseSchemaType extends Record<string, DatabasePropertyValue>,
 >(
 	args: ReturnType<typeof buildQueryScenario>,
 	options?: {

--- a/tests/runtime/config/load-config.contract.test.ts
+++ b/tests/runtime/config/load-config.contract.test.ts
@@ -17,6 +17,7 @@ import {
 
 const ORIGINAL_CWD = process.cwd();
 const ORIGINAL_NOTION_KEY = process.env.NOTION_KEY;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 
 afterEach(() => {
 	process.chdir(ORIGINAL_CWD);
@@ -24,6 +25,11 @@ afterEach(() => {
 		delete process.env.NOTION_KEY;
 	} else {
 		process.env.NOTION_KEY = ORIGINAL_NOTION_KEY;
+	}
+	if (ORIGINAL_NODE_ENV === undefined) {
+		delete process.env.NODE_ENV;
+	} else {
+		process.env.NODE_ENV = ORIGINAL_NODE_ENV;
 	}
 	clearConfigCache();
 	cleanupTempWorkspaces();
@@ -85,6 +91,111 @@ describe("config loading contracts", () => {
 		});
 	});
 
+	test("getNotionConfig loads NOTION_KEY from .env when shell env is absent", async () => {
+		const workspacePath = createTempWorkspace("config-dotenv-fallback-");
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env",
+			content: "NOTION_KEY=dotenv-auth-token\n",
+		});
+		process.chdir(workspacePath);
+		delete process.env.NOTION_KEY;
+
+		const config = await getNotionConfig();
+		expect(config).toEqual({
+			auth: "dotenv-auth-token",
+			databases: [],
+			agents: [],
+		});
+	});
+
+	test("getNotionConfig loads NOTION_KEY from .env.local when .env is absent", async () => {
+		const workspacePath = createTempWorkspace("config-dotenv-local-fallback-");
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env.local",
+			content: "NOTION_KEY=dotenv-local-token\n",
+		});
+		process.chdir(workspacePath);
+		delete process.env.NOTION_KEY;
+
+		const config = await getNotionConfig();
+		expect(config).toEqual({
+			auth: "dotenv-local-token",
+			databases: [],
+			agents: [],
+		});
+	});
+
+	test("getNotionConfig prefers .env.local over .env", async () => {
+		const workspacePath = createTempWorkspace("config-dotenv-local-over-base-");
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env",
+			content: "NOTION_KEY=dotenv-base-token\n",
+		});
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env.local",
+			content: "NOTION_KEY=dotenv-local-token\n",
+		});
+		process.chdir(workspacePath);
+		delete process.env.NOTION_KEY;
+
+		const config = await getNotionConfig();
+		expect(config.auth).toBe("dotenv-local-token");
+	});
+
+	test("getNotionConfig prefers .env.<NODE_ENV> over .env", async () => {
+		const workspacePath = createTempWorkspace("config-dotenv-env-over-base-");
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env",
+			content: "NOTION_KEY=dotenv-base-token\n",
+		});
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env.staging",
+			content: "NOTION_KEY=dotenv-staging-token\n",
+		});
+		process.chdir(workspacePath);
+		delete process.env.NOTION_KEY;
+		process.env.NODE_ENV = "staging";
+
+		const config = await getNotionConfig();
+		expect(config.auth).toBe("dotenv-staging-token");
+	});
+
+	test("getNotionConfig prefers .env.<NODE_ENV>.local over all dotenv variants", async () => {
+		const workspacePath = createTempWorkspace("config-dotenv-env-local-top-");
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env",
+			content: "NOTION_KEY=dotenv-base-token\n",
+		});
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env.local",
+			content: "NOTION_KEY=dotenv-local-token\n",
+		});
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env.staging",
+			content: "NOTION_KEY=dotenv-staging-token\n",
+		});
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env.staging.local",
+			content: "NOTION_KEY=dotenv-staging-local-token\n",
+		});
+		process.chdir(workspacePath);
+		delete process.env.NOTION_KEY;
+		process.env.NODE_ENV = "staging";
+
+		const config = await getNotionConfig();
+		expect(config.auth).toBe("dotenv-staging-local-token");
+	});
+
 	test("getNotionConfig honors cache until clearConfigCache is called", async () => {
 		const workspacePath = createTempWorkspace("config-cache-");
 		process.chdir(workspacePath);
@@ -126,5 +237,33 @@ describe("config loading contracts", () => {
 			MOCK_DATA_SOURCE_ID_B,
 		]);
 		expect(config.agents).toEqual(["agent-1"]);
+	});
+
+	test("getNotionConfig loads .env before importing notion.config", async () => {
+		const workspacePath = createTempWorkspace("config-dotenv-module-");
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env",
+			content: "NOTION_KEY=dotenv-module-token\n",
+		});
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: CODEGEN_EMIT_PATHS.notionConfigTs,
+			content: [
+				"const auth = process.env.NOTION_KEY || 'fallback-placeholder';",
+				"export default {",
+				"  auth,",
+				`  databases: ['${MOCK_DATA_SOURCE_ID}'],`,
+				"  agents: [],",
+				"};",
+			].join("\n"),
+		});
+		process.chdir(workspacePath);
+		delete process.env.NOTION_KEY;
+
+		const config = await getNotionConfig();
+		expect(config.auth).toBe("dotenv-module-token");
+		expect(config.databases).toEqual([MOCK_DATA_SOURCE_ID]);
+		expect(config.agents).toEqual([]);
 	});
 });

--- a/tests/runtime/helpers/patch-build-import-extensions.test.ts
+++ b/tests/runtime/helpers/patch-build-import-extensions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { rewriteRelativeImportSpecifiers } from "../../../scripts/patch-build-import-extensions.mjs";
+
+describe("patch build import extensions", () => {
+	test("rewrites static import and export specifiers without touching bare imports", () => {
+		const source = [
+			'import thing from "./thing";',
+			'export { thing } from "../shared/value";',
+			'import pkg from "some-package";',
+		].join("\n");
+
+		expect(rewriteRelativeImportSpecifiers(source)).toBe(
+			[
+				'import thing from "./thing.js";',
+				'export { thing } from "../shared/value.js";',
+				'import pkg from "some-package";',
+			].join("\n"),
+		);
+	});
+
+	test("rewrites dynamic import specifiers and preserves query or hash suffixes", () => {
+		const source = [
+			'const lazyValue = import("./lazy/module");',
+			'const withQuery = import("./feature?worker");',
+			'const withHash = import("./chunk#entry");',
+		].join("\n");
+
+		expect(rewriteRelativeImportSpecifiers(source)).toBe(
+			[
+				'const lazyValue = import("./lazy/module.js");',
+				'const withQuery = import("./feature.js?worker");',
+				'const withHash = import("./chunk.js#entry");',
+			].join("\n"),
+		);
+	});
+
+	test("leaves already-qualified and directory specifiers alone", () => {
+		const source = [
+			'import "./already.js";',
+			'import "../nested/index.mjs";',
+			'import "./folder/";',
+		].join("\n");
+
+		expect(rewriteRelativeImportSpecifiers(source)).toBe(source);
+	});
+});

--- a/tests/runtime/prisma-api/create.test.ts
+++ b/tests/runtime/prisma-api/create.test.ts
@@ -64,14 +64,40 @@ describe("create", () => {
 
 	test("createMany calls pages.create N times", async () => {
 		const client = createClient();
-		const results = await client.createMany({
-			properties: [
-				{ shopName: "Shop A", rating: 3, hasWifi: true },
-				{ shopName: "Shop B", rating: 5, hasWifi: false },
-			],
-		});
+		const results = await client.createMany([
+			{ properties: { shopName: "Shop A", rating: 3, hasWifi: true } },
+			{ properties: { shopName: "Shop B", rating: 5, hasWifi: false } },
+		]);
 		expect(results).toHaveLength(2);
 		expect(pagesCreateMock).toHaveBeenCalledTimes(2);
+	});
+
+	test("createMany forwards per-item icon, cover, and markdown", async () => {
+		const client = createClient();
+		const icon = { type: "emoji" as const, emoji: "📚" as const };
+		const cover = { type: "external" as const, external: { url: "https://example.com/cover.jpg" } };
+		const markdown = "# Book notes";
+		const results = await client.createMany([
+			{
+				properties: { shopName: "Shop A", rating: 3, hasWifi: true },
+				icon,
+				cover,
+			},
+			{
+				properties: { shopName: "Shop B", rating: 5, hasWifi: false },
+				markdown,
+			},
+		]);
+		expect(results).toHaveLength(2);
+		expect(pagesCreateMock).toHaveBeenCalledTimes(2);
+		expect(pagesCreateMock).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({ icon, cover }),
+		);
+		expect(pagesCreateMock).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ markdown }),
+		);
 	});
 
 	test("passes markdown content to API", async () => {

--- a/tests/runtime/resolve-notion-auth.contract.test.ts
+++ b/tests/runtime/resolve-notion-auth.contract.test.ts
@@ -2,15 +2,29 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
 	resolveNotionAuth,
 } from "../../src/config/resolveNotionAuth";
+import {
+	cleanupTempWorkspaces,
+	createTempWorkspace,
+	writeWorkspaceFile,
+} from "../helpers/temp-workspace";
 
+const ORIGINAL_CWD = process.cwd();
 const ORIGINAL_NOTION_KEY = process.env.NOTION_KEY;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 
 afterEach(() => {
+	process.chdir(ORIGINAL_CWD);
 	if (ORIGINAL_NOTION_KEY === undefined) {
 		delete process.env.NOTION_KEY;
 	} else {
 		process.env.NOTION_KEY = ORIGINAL_NOTION_KEY;
 	}
+	if (ORIGINAL_NODE_ENV === undefined) {
+		delete process.env.NODE_ENV;
+	} else {
+		process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+	}
+	cleanupTempWorkspaces();
 });
 
 describe("resolveNotionAuth", () => {
@@ -22,6 +36,45 @@ describe("resolveNotionAuth", () => {
 	test("falls back to NOTION_KEY when config auth is absent", () => {
 		process.env.NOTION_KEY = "env-token";
 		expect(resolveNotionAuth({})).toBe("env-token");
+	});
+
+	test("loads NOTION_KEY from .env in the current project root", () => {
+		const workspacePath = createTempWorkspace("resolve-auth-dotenv-");
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env",
+			content: "NOTION_KEY=dotenv-token\n",
+		});
+		process.chdir(workspacePath);
+		delete process.env.NOTION_KEY;
+
+		expect(resolveNotionAuth({})).toBe("dotenv-token");
+	});
+
+	test("loads NOTION_KEY from .env.local in the current project root", () => {
+		const workspacePath = createTempWorkspace("resolve-auth-dotenv-local-");
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env.local",
+			content: "NOTION_KEY=dotenv-local-token\n",
+		});
+		process.chdir(workspacePath);
+		delete process.env.NOTION_KEY;
+
+		expect(resolveNotionAuth({})).toBe("dotenv-local-token");
+	});
+
+	test("prefers shell NOTION_KEY over the same key in .env", () => {
+		const workspacePath = createTempWorkspace("resolve-auth-shell-over-dotenv-");
+		writeWorkspaceFile({
+			workspacePath,
+			relativePath: ".env",
+			content: "NOTION_KEY=dotenv-token\n",
+		});
+		process.chdir(workspacePath);
+		process.env.NOTION_KEY = "shell-token";
+
+		expect(resolveNotionAuth({})).toBe("shell-token");
 	});
 
 	test("prefers explicit config over environment", () => {

--- a/tests/runtime/response/properties/_pipeline-test-helpers.ts
+++ b/tests/runtime/response/properties/_pipeline-test-helpers.ts
@@ -8,6 +8,7 @@ import {
 	isColumnTypesWithOptions,
 	type ColumnDefinition,
 	type DatabaseColumns,
+	type DatabasePropertyValue,
 	type SupportedNotionColumnType,
 } from "../../../../src/client/database/types";
 import { queryDataSourceListResponse } from "../../../helpers/query-data-source-response";
@@ -37,13 +38,13 @@ function columnDefinitionForPipeline(
 }
 
 export interface PropertyPipelineCase {
-		propertyType: SupportedNotionColumnType;
-		validPropertyValue: NotionPropertyValue;
-		expectedValidValue: unknown;
-		mismatchedPropertyValue: NotionPropertyValue;
-		malformedPropertyValue: unknown;
-		expectedMalformedValue: unknown;
-	}
+	propertyType: SupportedNotionColumnType;
+	validPropertyValue: NotionPropertyValue;
+	expectedValidValue: DatabasePropertyValue;
+	mismatchedPropertyValue: NotionPropertyValue;
+	malformedPropertyValue: unknown;
+	expectedMalformedValue: unknown;
+}
 
 function buildSinglePageResponse(args: {
 	primaryValue: unknown;
@@ -71,7 +72,9 @@ function transformPrimaryValue(args: {
 	propertyValue: unknown;
 	includeRawResponse?: boolean;
 	includeUnmapped?: NotionPropertyValue;
-	validateSchema?: (result: Record<string, unknown>) => void;
+	validateSchema?: (
+		result: Partial<Record<string, DatabasePropertyValue>>,
+	) => void;
 }) {
 	let validateCalls = 0;
 	const rawResponse = buildSinglePageResponse({
@@ -92,7 +95,7 @@ function transformPrimaryValue(args: {
 	};
 
 	if (args.includeRawResponse) {
-		const output = buildQueryResponse<Record<string, unknown>>({
+		const output = buildQueryResponse<Record<string, DatabasePropertyValue>>({
 			response: rawResponse,
 			columns: pipelineColumns,
 			validateSchema,
@@ -101,7 +104,7 @@ function transformPrimaryValue(args: {
 		return { output, validateCalls, rawResponse };
 	}
 
-	const output = buildQueryResponse<Record<string, unknown>>({
+	const output = buildQueryResponse<Record<string, DatabasePropertyValue>>({
 		response: rawResponse,
 		columns: pipelineColumns,
 		validateSchema,
@@ -161,7 +164,8 @@ export function describePropertyPipelineCases(
 				propertyValue: testCase.malformedPropertyValue,
 			});
 
-			expect(output.results[0]).toEqual({
+			const malformedRow: unknown = output.results[0];
+			expect(malformedRow).toEqual({
 				[PRIMARY_CAMEL_COLUMN_NAME]: testCase.expectedMalformedValue,
 			});
 		});

--- a/website/content/api-reference.mdx
+++ b/website/content/api-reference.mdx
@@ -46,7 +46,7 @@ const notion = new NotionORM({
 | `findMany(args?)` | Query rows. Returns `Partial<Schema>[]` by default, `PaginateResult` with `after`, or `AsyncIterable` with `stream` ([source](/api-reference#findmany)) |
 | `count(args?)` | Returns the total number of matching rows ([source](/api-reference#count)) |
 | `create({ properties, icon?, cover?, markdown? })` | Creates a page with typed properties and optional markdown body content ([source](/api-reference#create)) |
-| `createMany({ properties })` | Creates multiple pages sequentially ([source](/api-reference#createmany)) |
+| `createMany([{ properties, icon?, cover?, markdown? }])` | Creates multiple pages sequentially ([source](/api-reference#createmany)) |
 | `update({ where: { id }, properties })` | Updates a single page by ID ([source](/api-reference#update)) |
 | `updateMany({ where, properties })` | Updates all pages matching a filter ([source](/api-reference#updatemany)) |
 | `upsert({ where, create, update })` | Creates or updates depending on whether a match exists ([source](/api-reference#upsert)) |
@@ -240,13 +240,21 @@ await notion.booksDb.create({
 
 Creates multiple pages sequentially and returns all responses.
 
+Accepts an array of `create(...)` payloads (`Array<{ properties; icon?; cover?; markdown? }>`), so every row can carry its own `icon`, `cover`, and `markdown` body in addition to `properties`.
+
 ```ts
-const results = await notion.booksDb.createMany({
-  properties: [
-    { bookName: "Book A", genre: ["Sci-Fi"], numberOfPages: 300 },
-    { bookName: "Book B", genre: ["Biography"], numberOfPages: 250 },
-  ],
-});
+const results = await notion.booksDb.createMany([
+  { properties: { bookName: "Book A", genre: ["Sci-Fi"], numberOfPages: 300 } },
+  { properties: { bookName: "Book B", genre: ["Biography"], numberOfPages: 250 } },
+  {
+    properties: { bookName: "Book C", genre: ["Fantasy"], numberOfPages: 420 },
+    icon: { type: "emoji", emoji: "📘" },
+  },
+  {
+    properties: { bookName: "Book D", genre: ["History"], numberOfPages: 380 },
+    markdown: "# Notes\n\n- Imported from archive",
+  },
+]);
 ```
 
 ---

--- a/website/playground-sources/orm-package-mock.ts
+++ b/website/playground-sources/orm-package-mock.ts
@@ -442,9 +442,7 @@ export type Create<Schema extends object> = {
 	markdown?: string;
 };
 
-export type CreateMany<Schema extends object> = {
-	properties: Schema[];
-};
+export type CreateMany<Schema extends object> = ReadonlyArray<Create<Schema>>;
 
 export type Update<Schema extends object> = {
 	where: { id: string };

--- a/website/src/site/demo/DemoPlayground.tsx
+++ b/website/src/site/demo/DemoPlayground.tsx
@@ -493,7 +493,7 @@ function createWorkspaceFiles(): Record<string, string> {
 	const MOCK_PACKAGE_NOTION_ID_PATTERNS =
 		"playground_modules/haustle-notion-orm/notion-id-patterns.ts" as const;
 	const MOCK_PACKAGE_BASE =
-		"playground_modules/haustle-notion-orm/build/src/base.ts" as const;
+		"playground_modules/haustle-notion-orm/base.ts" as const;
 	const MOCK_PACKAGE_PREFIX = "playground_modules/" as const;
 
 	const hiddenSupportFiles = [
@@ -506,7 +506,7 @@ function createWorkspaceFiles(): Record<string, string> {
 			playgroundFiles[MOCK_PACKAGE_NOTION_ID_PATTERNS],
 		],
 		[
-			"/node_modules/@haustle/notion-orm/build/src/base.ts",
+			"/node_modules/@haustle/notion-orm/base.ts",
 			playgroundFiles[MOCK_PACKAGE_BASE],
 		],
 		[
@@ -517,7 +517,8 @@ function createWorkspaceFiles(): Record<string, string> {
 					type: "module",
 					exports: {
 						".": "./index.ts",
-						"./build/src/base": "./build/src/base.ts",
+						"./base": "./base.ts",
+						"./build/src/base": "./base.ts",
 					},
 				},
 				null,


### PR DESCRIPTION
## Description

Previously, package publishing and consumer sync still relied on Bun-era assumptions and a narrower `createMany` contract. This change makes the branch Node-compatible end to end, emits environment-appropriate generated artifacts, and aligns runtime/config/client/docs behavior around that surface.

**Key changes:**

- **Stabilize package entrypoints** — add explicit `exports` and top-level `types` in `package.json`, expose `@haustle/notion-orm/base`, keep the legacy `./build/src/base` path for compatibility, and declare `engines.node` as `>=18`.
- **Patch emitted ESM imports for Node** — add `scripts/patch-build-import-extensions.mjs` and wire it into `build` so published `build/` files rewrite relative `import`/`export`/dynamic `import()` specifiers to explicit `.js` (including `index.js` directory targets).
- **Resolve codegen output by consumer environment** — introduce `resolveCodegenEnvironment()`, `codegenArtifactFileName()`, and `codegenIndexSourcePath()` so generated `notion/index`, `databases/*`, and `agents/*` emit as `.ts` or `.js` based on project runtime while keeping runtime import specifiers `.js`.
- **Split and harden config loading** — extract config discovery/types/modules (`findConfigFile`, `notion-config-filenames`, `loadDotEnvFromCwd`, `types`) and load `.env*` files with precedence before importing `notion.config.*`.
- **Refactor CLI sync and shared runtime constants** — switch the CLI shebang to Node, extract `SyncProgressRenderer`, add generated-entrypoint usage hints after sync, return `agentKeys` from agent sync, and centralize runtime values in `PACKAGE_RUNTIME_CONSTANTS`.
- **Update `createMany` payload shape** — change `CreateMany` to `ReadonlyArray<Create<...>>`, support per-item `icon`/`cover`/`markdown`, and reject removed wrapper shapes (`{ properties: [...] }` / `{ items: [...] }`) with explicit guidance.
- **Expand docs and regression coverage** — refresh `README.md`, add architecture/site API updates for the new contracts, and extend tests across JS/TS codegen emission, consumer typecheck packaging flow, dotenv precedence, import rewrite behavior, and `createMany` array payloads.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Ran `npm install`, `npm run build`, and `node --test --import tsx tests/codegen/generated-client-calls.e2e.test.ts`.