### PR TITLE
Fix config load notion.config.ts in node consumers

### DIFF
--- a/.cursor/skills/orm-build-sync/SKILL.md
+++ b/.cursor/skills/orm-build-sync/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: orm-build-sync
-description: Builds @haustle/notion-orm from source, links it into orm-testing, and runs notion sync to refresh generated Notion artifacts. Use when the user wants to ship ORM changes into the local orm-testing sandbox, says build and sync, link and notion sync, or mentions orm-build-sync.
+description: Builds @haustle/notion-orm from source, links it into testing-orm, and runs notion sync to refresh generated Notion artifacts. Use when the user wants to ship ORM changes into the local testing-orm sandbox, says build and sync, link and notion sync, or mentions orm-build-sync.
 ---
 
-# ORM build + orm-testing sync
+# ORM build + testing-orm sync
 
 ## When to use
 
-- After changing emitters, CLI, or package exports in this repo and you want `orm-testing` to pick them up.
-- When the user asks to build ORM and run `notion sync` in `orm-testing`.
+- After changing emitters, CLI, or package exports in this repo and you want `testing-orm` to pick them up.
+- When the user asks to build ORM and run `notion sync` in `testing-orm`.
 
 ## Paths
 
@@ -17,7 +17,7 @@ Assume these unless the user specifies otherwise:
 | Role        | Path |
 |-------------|------|
 | ORM package | `/Users/tyrus/repos/orm` |
-| Sandbox app | `/Users/tyrus/repos/orm-testing` |
+| Sandbox app | `/Users/tyrus/repos/testing-orm` |
 
 ## Workflow
 
@@ -26,21 +26,21 @@ Run in order; stop if a step fails.
 ### 1) Build and register the package
 
 ```bash
-cd /Users/tyrus/repos/orm && bun run build
+cd /Users/tyrus/repos/orm && bun run build && bun link
 ```
 
-`bun run build` runs `tsc` into `build/` and `bun link` so `@haustle/notion-orm` is registered for local linking.
+`bun run build` compiles the package into `build/`. Run `bun link` immediately after so `@haustle/notion-orm` is registered for local linking.
 
-### 2) Link into orm-testing
+### 2) Link into testing-orm
 
 ```bash
-cd /Users/tyrus/repos/orm-testing && bun link @haustle/notion-orm
+cd /Users/tyrus/repos/testing-orm && bun link @haustle/notion-orm
 ```
 
 ### 3) Regenerate generated Notion files
 
 ```bash
-cd /Users/tyrus/repos/orm-testing && bunx notion sync
+cd /Users/tyrus/repos/testing-orm && bunx notion sync
 ```
 
 Use `bunx notion sync` so the CLI resolves from the linked install. If `bun notion sync` works in that project, it is an acceptable alternative.
@@ -48,18 +48,19 @@ Use `bunx notion sync` so the CLI resolves from the linked install. If `bun noti
 ## One-shot chain
 
 ```bash
-cd /Users/tyrus/repos/orm && bun run build && cd /Users/tyrus/repos/orm-testing && bun link @haustle/notion-orm && bunx notion sync
+cd /Users/tyrus/repos/orm && bun run build && bun link && cd /Users/tyrus/repos/testing-orm && bun link @haustle/notion-orm && bunx notion sync
 ```
 
 ## Checklist
 
 ```text
 - [ ] ORM: bun run build (PASS)
-- [ ] orm-testing: bun link @haustle/notion-orm (PASS)
-- [ ] orm-testing: bunx notion sync (PASS)
+- [ ] ORM: bun link (PASS)
+- [ ] testing-orm: bun link @haustle/notion-orm (PASS)
+- [ ] testing-orm: bunx notion sync (PASS)
 ```
 
 ## Notes
 
-- `orm-testing` needs a valid Notion config / env for sync to talk to the API; failures are often config or network, not the link step.
+- `testing-orm` needs a valid Notion config / env for sync to talk to the API; failures are often config or network, not the link step.
 - For validating behavior beyond codegen, see the [orm-consumer-link-test](../orm-consumer-link-test/SKILL.md) skill.

--- a/.cursor/skills/orm-build-sync/SKILL.md
+++ b/.cursor/skills/orm-build-sync/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: orm-build-sync
-description: Builds @haustle/notion-orm from source, links it into testing-orm, and runs notion sync to refresh generated Notion artifacts. Use when the user wants to ship ORM changes into the local testing-orm sandbox, says build and sync, link and notion sync, or mentions orm-build-sync.
+description: Builds @haustle/notion-orm from source, links it into orm-testing, and runs notion sync to refresh generated Notion artifacts. Use when the user wants to ship ORM changes into the local orm-testing sandbox, says build and sync, link and notion sync, or mentions orm-build-sync.
 ---
 
-# ORM build + testing-orm sync
+# ORM build + orm-testing sync
 
 ## When to use
 
-- After changing emitters, CLI, or package exports in this repo and you want `testing-orm` to pick them up.
-- When the user asks to build ORM and run `notion sync` in `testing-orm`.
+- After changing emitters, CLI, or package exports in this repo and you want `orm-testing` to pick them up.
+- When the user asks to build ORM and run `notion sync` in `orm-testing`.
 
 ## Paths
 
@@ -17,7 +17,7 @@ Assume these unless the user specifies otherwise:
 | Role        | Path |
 |-------------|------|
 | ORM package | `/Users/tyrus/repos/orm` |
-| Sandbox app | `/Users/tyrus/repos/testing-orm` |
+| Sandbox app | `/Users/tyrus/repos/orm-testing` |
 
 ## Workflow
 
@@ -26,21 +26,21 @@ Run in order; stop if a step fails.
 ### 1) Build and register the package
 
 ```bash
-cd /Users/tyrus/repos/orm && bun run build && bun link
+cd /Users/tyrus/repos/orm && bun run build
 ```
 
-`bun run build` compiles the package into `build/`. Run `bun link` immediately after so `@haustle/notion-orm` is registered for local linking.
+`bun run build` runs `tsc` into `build/` and `bun link` so `@haustle/notion-orm` is registered for local linking.
 
-### 2) Link into testing-orm
+### 2) Link into orm-testing
 
 ```bash
-cd /Users/tyrus/repos/testing-orm && bun link @haustle/notion-orm
+cd /Users/tyrus/repos/orm-testing && bun link @haustle/notion-orm
 ```
 
 ### 3) Regenerate generated Notion files
 
 ```bash
-cd /Users/tyrus/repos/testing-orm && bunx notion sync
+cd /Users/tyrus/repos/orm-testing && bunx notion sync
 ```
 
 Use `bunx notion sync` so the CLI resolves from the linked install. If `bun notion sync` works in that project, it is an acceptable alternative.
@@ -48,19 +48,18 @@ Use `bunx notion sync` so the CLI resolves from the linked install. If `bun noti
 ## One-shot chain
 
 ```bash
-cd /Users/tyrus/repos/orm && bun run build && bun link && cd /Users/tyrus/repos/testing-orm && bun link @haustle/notion-orm && bunx notion sync
+cd /Users/tyrus/repos/orm && bun run build && cd /Users/tyrus/repos/orm-testing && bun link @haustle/notion-orm && bunx notion sync
 ```
 
 ## Checklist
 
 ```text
 - [ ] ORM: bun run build (PASS)
-- [ ] ORM: bun link (PASS)
-- [ ] testing-orm: bun link @haustle/notion-orm (PASS)
-- [ ] testing-orm: bunx notion sync (PASS)
+- [ ] orm-testing: bun link @haustle/notion-orm (PASS)
+- [ ] orm-testing: bunx notion sync (PASS)
 ```
 
 ## Notes
 
-- `testing-orm` needs a valid Notion config / env for sync to talk to the API; failures are often config or network, not the link step.
+- `orm-testing` needs a valid Notion config / env for sync to talk to the API; failures are often config or network, not the link step.
 - For validating behavior beyond codegen, see the [orm-consumer-link-test](../orm-consumer-link-test/SKILL.md) skill.

--- a/.cursor/skills/orm-consumer-pack-test/SKILL.md
+++ b/.cursor/skills/orm-consumer-pack-test/SKILL.md
@@ -26,9 +26,9 @@ If `consumer_app_paths` are missing, default to `orm_repo_path/../orm-testing` w
 ## Preflight Checklist (run before workflow)
 
 ```text
-- [ ] Clean compile output first: `rm -rf build && bunx tsc`
+- [ ] Build ORM with the real release pipeline: `bun run build` (or `rm -rf build && tsc && node ./scripts/patch-build-import-extensions.mjs` + `chmod +x build/src/cli/index.js`). Do **not** use `bunx tsc` alone — the published CLI requires the import-extension patch or `notion sync` / `notion` will fail in consumers with missing `.js` modules.
 - [ ] Confirm source uses package-safe internal imports (no bare internal aliases like `config/helpers` or `cli/helpers`)
-- [ ] Confirm consumer has exactly one `@haustle/notion-orm` dependency entry in `package.json`
+- [ ] Confirm consumer has exactly one `@haustle/notion-orm` dependency entry in `package.json` (fix duplicate keys if a tool rewrote the file)
 - [ ] If dependency history looks noisy/stale, delete consumer `bun.lock` and run `bun install`
 - [ ] Confirm tarball ignores are in place (`*.tgz` in ORM `.gitignore`)
 - [ ] Confirm scripts/env needed for integration smoke are present (`NOTION_KEY`)
@@ -41,23 +41,24 @@ Copy this checklist and track progress:
 
 ```text
 ORM pack consumer validation progress
-- [ ] Build compiled output in ORM repo (no link required)
+- [ ] Build ORM with `bun run build` (includes import patch; required for CLI)
 - [ ] Create tarball with npm pack
 - [ ] Install tarball in each consuming app (bun add …tgz)
-- [ ] Regenerate generated types in each app if needed (notion sync)
+- [ ] (orm-testing) Optional but recommended: full refresh — see **“Full refresh: `orm-testing`”** below
+- [ ] Regenerate generated types in each app if needed (`notion sync`)
 - [ ] Run validation/tests in each consuming app
 - [ ] Report using structured template (pack pipeline, per-command results, test counts, DB add/query/property coverage)
 ```
 
 ### 1) Build package in ORM repo
 
-From `orm_repo_path`, produce `build/` with TypeScript only (avoids coupling to scripts that run `bun link`):
+From `orm_repo_path`, run the package **release-style** build so the CLI works from the tarball:
 
 ```bash
-rm -rf build && bunx tsc
+bun run build
 ```
 
-If the repo’s `bun run build` is known to be link-free, that is acceptable; prefer a **pure compile** when in doubt.
+This runs `tsc` plus `patch-build-import-extensions.mjs` and marks the CLI executable. **Bare `tsc` is insufficient** for validating `notion` / `notion sync` in a consumer.
 
 ### 2) Create the tarball
 
@@ -83,7 +84,56 @@ Example when `orm` and `orm-testing` are sibling repos:
 bun add ../orm/haustle-notion-orm-0.0.44.tgz
 ```
 
+**Bun caveat:** `bun add ../orm/haustle-notion-orm-<version>.tgz` sometimes hits a **DependencyLoop** error. If that happens, **copy** the `.tgz` into the consumer app directory and install locally:
+
+```bash
+cp "$orm_repo_path/haustle-notion-orm-<version>.tgz" /path/to/consumer/
+cd /path/to/consumer && bun add ./haustle-notion-orm-<version>.tgz
+```
+
+After `bun add`, confirm `package.json` has a **single** `@haustle/notion-orm` dependency (no duplicate keys).
+
 Re-running `bun add` after a new pack replaces the installed package with the new tarball.
+
+### Full refresh: `orm-testing` (recommended)
+
+Use this when you want to exercise **`notion init` → `notion add` → `notion sync`** end-to-end on the packed CLI, not only swap the dependency.
+
+1. **Record IDs** from the existing `notion.config.ts` (or `.js`): copy `databases` and `agents` UUIDs you need to restore. For databases, `notion add` accepts dashed or undashed IDs; use the **data source** ID for the Coffee Shop–style DB in `orm-testing`.
+2. **Remove config and generated types** (from consumer app root):
+
+   ```bash
+   rm -f notion.config.ts notion.config.js
+   rm -rf notion
+   ```
+
+3. **Install the packed ORM** (see step 3) so `bunx notion` resolves to the tarball build.
+4. **Init + add database(s):**
+
+   ```bash
+   bunx notion init --ts   # or --js; match the consumer project
+   bunx notion add <data-source-id-or-url> --type database
+   ```
+
+   Repeat `notion add` for each database you recorded. There is no `notion add --type agent`; agent IDs are **refreshed by `notion sync`** once the Agents SDK is available.
+
+5. **Agents SDK (if the app uses agents):**
+
+   ```bash
+   bunx notion setup-agents-sdk
+   ```
+
+   This may rewrite `package.json`. **Inspect and dedupe** dependency keys (e.g. keep a single `@notionhq/agents-client`, typically `file:../notion-agents-sdk` for sibling repos). Run `bun install` if the lockfile warned about duplicates.
+
+6. **Full sync:**
+
+   ```bash
+   bunx notion sync
+   ```
+
+7. **Validate** (e.g. `bun run coffee-shop`, `bun test`).
+
+Treat restored `notion.config.ts` and `notion/` as **regenerated**; do not assume byte-identical output vs. the pre-refresh files.
 
 ### 4) Regenerate generated types (when applicable)
 
@@ -182,8 +232,10 @@ Short runs may collapse the property table to a bullet list, but **do not** omit
 
 ## Failure Handling
 
-- If `tsc` or `npm pack` fails, stop and report before touching consumers.
-- If `bun add` fails, confirm the tarball path and that `npm pack` completed in `orm_repo_path`.
+- If `bun run build` or `npm pack` fails, stop and report before touching consumers.
+- If `bun add` fails with **DependencyLoop**, copy the `.tgz` into the consumer and `bun add ./haustle-notion-orm-<version>.tgz`.
+- If `bun install` or `bun.lock` errors with **duplicate key** or **InvalidPackageKey**, open `package.json` and ensure each dependency name appears once; then delete `bun.lock` and run `bun install` again.
+- If `notion` fails with `ERR_MODULE_NOT_FOUND` for extensionless paths under `build/src/`, rebuild ORM with `bun run build` and reinstall the new tarball.
 - Include exact failing command and error details for each failure.
 
 ## Notes

--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,8 @@
 	"ignoreFiles": [
 		"tests/golden/**",
 		"tests/agents/mealAgent.d.ts",
-		"website/playground-sources/**"
+		"website/playground-sources/**",
+		"website/content/**"
 	],
 	"workspaces": {
 		".": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@haustle/notion-orm",
-	"version": "0.0.47",
+	"version": "0.0.48",
 	"type": "module",
 	"description": "tool to bring notion databases schemas/types to typescript",
 	"main": "build/src/index.js",

--- a/src/ast/shared/emit/config-emitter.ts
+++ b/src/ast/shared/emit/config-emitter.ts
@@ -4,6 +4,7 @@ import * as parser from "@babel/parser";
 import * as t from "@babel/types";
 import * as ts from "typescript";
 import { NOTION_CONFIG_BASENAME } from "../../../config/notion-config-filenames";
+import type { NotionConfigType } from "../../../config/types";
 import { codegenArtifactFileName } from "../codegen-environment";
 import {
 	createEmitContext,
@@ -11,7 +12,7 @@ import {
 	type TsEmitContext,
 } from "./ts-emit-core";
 
-export type ConfigListKey = "databases" | "agents";
+export type ConfigListKey = Exclude<keyof NotionConfigType, "auth">;
 
 export interface ConfigListItem {
 	value: string;
@@ -171,6 +172,116 @@ export function renderConfigTemplateModule(args: {
 	} = args;
 	return printTsNodes({
 		nodes: buildConfigTemplateModuleAst({ isTS }),
+		context,
+	});
+}
+
+function createAuthLiteralVariableStatement(
+	authValue: string,
+): ts.VariableStatement {
+	return ts.factory.createVariableStatement(
+		undefined,
+		ts.factory.createVariableDeclarationList(
+			[
+				ts.factory.createVariableDeclaration(
+					ts.factory.createIdentifier("auth"),
+					undefined,
+					undefined,
+					ts.factory.createStringLiteral(authValue),
+				),
+			],
+			ts.NodeFlags.Const,
+		),
+	);
+}
+
+/**
+ * Same module shape as {@link buildConfigTemplateModuleAst} (auth variable +
+ * `NotionConfig` object + default export) but with literal `auth` and list
+ * values. Used for tests and fixtures; not for `notion init`.
+ */
+export function buildLiteralNotionConfigModuleAst(args: {
+	config: NotionConfigType;
+	isTS: boolean;
+}): ts.Statement[] {
+	const { config, isTS } = args;
+	const authVariable = createAuthLiteralVariableStatement(config.auth);
+	const notionConfigVariable = ts.factory.createVariableStatement(
+		undefined,
+		ts.factory.createVariableDeclarationList(
+			[
+				ts.factory.createVariableDeclaration(
+					ts.factory.createIdentifier("NotionConfig"),
+					undefined,
+					undefined,
+					ts.factory.createObjectLiteralExpression(
+						[
+							ts.factory.createShorthandPropertyAssignment(
+								ts.factory.createIdentifier("auth"),
+							),
+							ts.factory.createPropertyAssignment(
+								ts.factory.createIdentifier("databases"),
+								ts.factory.createArrayLiteralExpression(
+									config.databases.map((id) =>
+										ts.factory.createStringLiteral(id),
+									),
+									true,
+								),
+							),
+							ts.factory.createPropertyAssignment(
+								ts.factory.createIdentifier("agents"),
+								ts.factory.createArrayLiteralExpression(
+									config.agents.map((id) =>
+										ts.factory.createStringLiteral(id),
+									),
+									true,
+								),
+							),
+						],
+						true,
+					),
+				),
+			],
+			ts.NodeFlags.Const,
+		),
+	);
+	const exportStatement = isTS
+		? ts.factory.createExportAssignment(
+				undefined,
+				false,
+				ts.factory.createIdentifier("NotionConfig"),
+			)
+		: ts.factory.createExpressionStatement(
+				ts.factory.createBinaryExpression(
+					ts.factory.createPropertyAccessExpression(
+						ts.factory.createIdentifier("module"),
+						ts.factory.createIdentifier("exports"),
+					),
+					ts.factory.createToken(ts.SyntaxKind.EqualsToken),
+					ts.factory.createIdentifier("NotionConfig"),
+				),
+			);
+	return [authVariable, notionConfigVariable, exportStatement];
+}
+
+/**
+ * Renders a literal `notion.config` module (see
+ * {@link buildLiteralNotionConfigModuleAst}) for tests and generated fixtures.
+ */
+export function renderLiteralNotionConfigModule(args: {
+	config: NotionConfigType;
+	isTS: boolean;
+	context?: TsEmitContext;
+}): string {
+	const {
+		config,
+		isTS,
+		context = createEmitContext({
+			fileName: codegenArtifactFileName(NOTION_CONFIG_BASENAME, "typescript"),
+		}),
+	} = args;
+	return printTsNodes({
+		nodes: buildLiteralNotionConfigModuleAst({ config, isTS }),
 		context,
 	});
 }

--- a/src/ast/shared/emit/config-emitter.ts
+++ b/src/ast/shared/emit/config-emitter.ts
@@ -90,51 +90,8 @@ function createConfigProperty(args: {
 	return property;
 }
 
-/**
- * Builds AST nodes for a starter `notion.config` module.
- *
- * Example:
- * `buildConfigTemplateModuleAst({ isTS: true })`
- * builds:
- * - `const auth = process.env.NOTION_KEY || "...";`
- * - `const NotionConfig = { auth, databases: [], agents: [] };`
- * - `export default NotionConfig`
- */
-export function buildConfigTemplateModuleAst(args: {
-	isTS: boolean;
-}): ts.Statement[] {
-	const { isTS } = args;
-	const authVariable = createAuthVariableStatement();
-	const notionConfigVariable = ts.factory.createVariableStatement(
-		undefined,
-		ts.factory.createVariableDeclarationList(
-			[
-				ts.factory.createVariableDeclaration(
-					ts.factory.createIdentifier("NotionConfig"),
-					undefined,
-					undefined,
-					ts.factory.createObjectLiteralExpression(
-						[
-							ts.factory.createShorthandPropertyAssignment(
-								ts.factory.createIdentifier("auth"),
-							),
-							createConfigProperty({
-								name: "databases",
-								helpText: "Use: notion add <database-id> --type database",
-							}),
-							createConfigProperty({
-								name: "agents",
-								helpText: "Agents are auto-populated by: notion sync",
-							}),
-						],
-						true,
-					),
-				),
-			],
-			ts.NodeFlags.Const,
-		),
-	);
-	const exportStatement = isTS
+function createConfigExportStatement(isTS: boolean): ts.Statement {
+	return isTS
 		? ts.factory.createExportAssignment(
 				undefined,
 				false,
@@ -150,7 +107,93 @@ export function buildConfigTemplateModuleAst(args: {
 					ts.factory.createIdentifier("NotionConfig"),
 				),
 			);
-	return [authVariable, notionConfigVariable, exportStatement];
+}
+
+/**
+ * Shared module shape: auth variable, `const NotionConfig = { ... }`, then
+ * `export default` (TS) or `module.exports` (CJS).
+ *
+ * When `config` is omitted, builds the `notion init` template: env-based `auth`,
+ * empty `databases`/`agents` with help comments. When `config` is set, builds
+ * literal `auth` and ID lists (tests/fixtures).
+ */
+function buildNotionConfigModuleAst(args: {
+	isTS: boolean;
+	config?: NotionConfigType;
+}): ts.Statement[] {
+	const { isTS, config } = args;
+	const authVariable = config
+		? createAuthLiteralVariableStatement(config.auth)
+		: createAuthVariableStatement();
+
+	const listProperties: ts.ObjectLiteralElementLike[] = config
+		? [
+				ts.factory.createPropertyAssignment(
+					ts.factory.createIdentifier("databases"),
+					ts.factory.createArrayLiteralExpression(
+						config.databases.map((id) => ts.factory.createStringLiteral(id)),
+						true,
+					),
+				),
+				ts.factory.createPropertyAssignment(
+					ts.factory.createIdentifier("agents"),
+					ts.factory.createArrayLiteralExpression(
+						config.agents.map((id) => ts.factory.createStringLiteral(id)),
+						true,
+					),
+				),
+			]
+		: [
+				createConfigProperty({
+					name: "databases",
+					helpText: "Use: notion add <database-id> --type database",
+				}),
+				createConfigProperty({
+					name: "agents",
+					helpText: "Agents are auto-populated by: notion sync",
+				}),
+			];
+
+	const notionConfigVariable = ts.factory.createVariableStatement(
+		undefined,
+		ts.factory.createVariableDeclarationList(
+			[
+				ts.factory.createVariableDeclaration(
+					ts.factory.createIdentifier("NotionConfig"),
+					undefined,
+					undefined,
+					ts.factory.createObjectLiteralExpression(
+						[
+							ts.factory.createShorthandPropertyAssignment(
+								ts.factory.createIdentifier("auth"),
+							),
+							...listProperties,
+						],
+						true,
+					),
+				),
+			],
+			ts.NodeFlags.Const,
+		),
+	);
+
+	return [authVariable, notionConfigVariable, createConfigExportStatement(isTS)];
+}
+
+/**
+ * Builds AST nodes for a starter `notion.config` module.
+ *
+ * Example:
+ * `buildConfigTemplateModuleAst({ isTS: true })`
+ * builds:
+ * - `const auth = process.env.NOTION_KEY || "...";`
+ * - `const NotionConfig = { auth, databases: [], agents: [] };`
+ * - `export default NotionConfig`
+ */
+export function buildConfigTemplateModuleAst(args: {
+	isTS: boolean;
+}): ts.Statement[] {
+	return buildNotionConfigModuleAst({ isTS: args.isTS });
 }
 
 /**
@@ -171,7 +214,7 @@ export function renderConfigTemplateModule(args: {
 		}),
 	} = args;
 	return printTsNodes({
-		nodes: buildConfigTemplateModuleAst({ isTS }),
+		nodes: buildNotionConfigModuleAst({ isTS }),
 		context,
 	});
 }
@@ -196,72 +239,14 @@ function createAuthLiteralVariableStatement(
 }
 
 /**
- * Same module shape as {@link buildConfigTemplateModuleAst} (auth variable +
- * `NotionConfig` object + default export) but with literal `auth` and list
+ * Like {@link buildConfigTemplateModuleAst} but with literal `auth` and list
  * values. Used for tests and fixtures; not for `notion init`.
  */
 export function buildLiteralNotionConfigModuleAst(args: {
 	config: NotionConfigType;
 	isTS: boolean;
 }): ts.Statement[] {
-	const { config, isTS } = args;
-	const authVariable = createAuthLiteralVariableStatement(config.auth);
-	const notionConfigVariable = ts.factory.createVariableStatement(
-		undefined,
-		ts.factory.createVariableDeclarationList(
-			[
-				ts.factory.createVariableDeclaration(
-					ts.factory.createIdentifier("NotionConfig"),
-					undefined,
-					undefined,
-					ts.factory.createObjectLiteralExpression(
-						[
-							ts.factory.createShorthandPropertyAssignment(
-								ts.factory.createIdentifier("auth"),
-							),
-							ts.factory.createPropertyAssignment(
-								ts.factory.createIdentifier("databases"),
-								ts.factory.createArrayLiteralExpression(
-									config.databases.map((id) =>
-										ts.factory.createStringLiteral(id),
-									),
-									true,
-								),
-							),
-							ts.factory.createPropertyAssignment(
-								ts.factory.createIdentifier("agents"),
-								ts.factory.createArrayLiteralExpression(
-									config.agents.map((id) =>
-										ts.factory.createStringLiteral(id),
-									),
-									true,
-								),
-							),
-						],
-						true,
-					),
-				),
-			],
-			ts.NodeFlags.Const,
-		),
-	);
-	const exportStatement = isTS
-		? ts.factory.createExportAssignment(
-				undefined,
-				false,
-				ts.factory.createIdentifier("NotionConfig"),
-			)
-		: ts.factory.createExpressionStatement(
-				ts.factory.createBinaryExpression(
-					ts.factory.createPropertyAccessExpression(
-						ts.factory.createIdentifier("module"),
-						ts.factory.createIdentifier("exports"),
-					),
-					ts.factory.createToken(ts.SyntaxKind.EqualsToken),
-					ts.factory.createIdentifier("NotionConfig"),
-				),
-			);
-	return [authVariable, notionConfigVariable, exportStatement];
+	return buildNotionConfigModuleAst({ isTS: args.isTS, config: args.config });
 }
 
 /**
@@ -281,7 +266,7 @@ export function renderLiteralNotionConfigModule(args: {
 		}),
 	} = args;
 	return printTsNodes({
-		nodes: buildLiteralNotionConfigModuleAst({ config, isTS }),
+		nodes: buildNotionConfigModuleAst({ config, isTS }),
 		context,
 	});
 }

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,3 +1,6 @@
+import fs from "fs/promises";
+import path from "path";
+import { randomUUID } from "crypto";
 import { pathToFileURL } from "url";
 import { findConfigFile } from "./findConfigFile.js";
 import { loadDotEnvFromCwd } from "./loadDotEnvFromCwd";
@@ -39,6 +42,9 @@ function parseNotionConfig(input: unknown): NotionConfigType {
  */
 async function loadUserConfig(absolutePath: string): Promise<unknown> {
 	try {
+		if (path.extname(absolutePath) === ".ts") {
+			return await loadTypeScriptConfig(absolutePath);
+		}
 		const importPath = pathToFileURL(absolutePath).href;
 		const mod = await import(importPath);
 		return mod.default ?? mod;
@@ -46,6 +52,27 @@ async function loadUserConfig(absolutePath: string): Promise<unknown> {
 		throw new Error(
 			`Failed to load config from '${absolutePath}': ${getErrorMessage(error)}`,
 		);
+	}
+}
+
+/**
+ * `notion init --ts` emits JavaScript-compatible source with a `.ts` extension.
+ * Plain Node cannot import `.ts` directly, so mirror it to a temporary `.mjs`
+ * alongside the config and load that file instead.
+ */
+async function loadTypeScriptConfig(absolutePath: string): Promise<unknown> {
+	const configSource = await fs.readFile(absolutePath, "utf8");
+	const runtimePath = path.join(
+		path.dirname(absolutePath),
+		`${path.basename(absolutePath, ".ts")}.runtime-${randomUUID()}.mjs`,
+	);
+	try {
+		await fs.writeFile(runtimePath, configSource);
+		const importPath = pathToFileURL(runtimePath).href;
+		const mod = await import(importPath);
+		return mod.default ?? mod;
+	} finally {
+		await fs.rm(runtimePath, { force: true });
 	}
 }
 

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -41,18 +41,12 @@ function parseNotionConfig(input: unknown): NotionConfigType {
  * JS-compatible template emitted by `notion init --ts`, not arbitrary TS syntax.
  */
 async function loadUserConfig(absolutePath: string): Promise<unknown> {
-	try {
-		if (path.extname(absolutePath) === ".ts") {
-			return await loadJsCompatibleTsConfig(absolutePath);
-		}
-		const importPath = pathToFileURL(absolutePath).href;
-		const mod = await import(importPath);
-		return mod.default ?? mod;
-	} catch (error: unknown) {
-		throw new Error(
-			`Failed to load config from '${absolutePath}': ${getErrorMessage(error)}`,
-		);
+	if (path.extname(absolutePath) === ".ts") {
+		return await loadJsCompatibleTsConfig(absolutePath);
 	}
+	const importPath = pathToFileURL(absolutePath).href;
+	const mod = await import(importPath);
+	return mod.default ?? mod;
 }
 
 /**

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -37,13 +37,13 @@ function parseNotionConfig(input: unknown): NotionConfigType {
 /**
  * Dynamically loads the user's notion.config file via `import()`.
  * Use a `file://` URL so Node, Bun, and other ESM runtimes resolve the path consistently.
- * Plain Node loads `.js`/`.mjs` natively; `.ts` requires a runtime that can execute TypeScript
- * (or compile the config to JavaScript first).
+ * Plain Node loads `.js`/`.mjs` natively. For `.ts`, we only support the
+ * JS-compatible template emitted by `notion init --ts`, not arbitrary TS syntax.
  */
 async function loadUserConfig(absolutePath: string): Promise<unknown> {
 	try {
 		if (path.extname(absolutePath) === ".ts") {
-			return await loadTypeScriptConfig(absolutePath);
+			return await loadJsCompatibleTsConfig(absolutePath);
 		}
 		const importPath = pathToFileURL(absolutePath).href;
 		const mod = await import(importPath);
@@ -56,11 +56,11 @@ async function loadUserConfig(absolutePath: string): Promise<unknown> {
 }
 
 /**
- * `notion init --ts` emits JavaScript-compatible source with a `.ts` extension.
- * Plain Node cannot import `.ts` directly, so mirror it to a temporary `.mjs`
- * alongside the config and load that file instead.
+ * `notion init --ts` emits JS-compatible source with a `.ts` extension.
+ * Keep the real project-relative module resolution by mirroring that source to a
+ * temporary sibling `.mjs` file for import under plain Node.
  */
-async function loadTypeScriptConfig(absolutePath: string): Promise<unknown> {
+async function loadJsCompatibleTsConfig(absolutePath: string): Promise<unknown> {
 	const configSource = await fs.readFile(absolutePath, "utf8");
 	const runtimePath = path.join(
 		path.dirname(absolutePath),
@@ -68,9 +68,17 @@ async function loadTypeScriptConfig(absolutePath: string): Promise<unknown> {
 	);
 	try {
 		await fs.writeFile(runtimePath, configSource);
-		const importPath = pathToFileURL(runtimePath).href;
-		const mod = await import(importPath);
-		return mod.default ?? mod;
+		try {
+			const importPath = pathToFileURL(runtimePath).href;
+			const mod = await import(importPath);
+			return mod.default ?? mod;
+		} catch (error: unknown) {
+			throw new Error(
+				"Plain Node only supports JS-compatible notion.config.ts files " +
+					"(like the template emitted by `notion init --ts`). " +
+					getErrorMessage(error),
+			);
+		}
 	} finally {
 		await fs.rm(runtimePath, { force: true });
 	}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { objectKeys } from "../typeUtils";
 
 export const notionConfigSchema = z.object({
 	auth: z.string().min(1, "Missing 'auth' field in notion config"),
@@ -7,3 +8,8 @@ export const notionConfigSchema = z.object({
 });
 
 export type NotionConfigType = z.infer<typeof notionConfigSchema>;
+
+/** Runtime key list derived from the Zod object shape (auth, databases, agents). */
+export const NOTION_CONFIG_FIELD_KEYS = objectKeys(
+	notionConfigSchema.shape,
+) satisfies ReadonlyArray<keyof NotionConfigType>;

--- a/tests/codegen/config-emitter.test.ts
+++ b/tests/codegen/config-emitter.test.ts
@@ -4,9 +4,12 @@ import * as t from "@babel/types";
 import * as ts from "typescript";
 import {
 	buildConfigTemplateModuleAst,
+	buildLiteralNotionConfigModuleAst,
 	renderConfigTemplateModule,
+	renderLiteralNotionConfigModule,
 	updateConfigListInConfigModule,
 } from "../../src/ast/shared/emit/config-emitter";
+import { NOTION_CONFIG_FIELD_KEYS } from "../../src/config/types";
 import {
 	createEmitContext,
 	printTsNodes,
@@ -97,6 +100,37 @@ describe("config emitter", () => {
 		expect(nodes[1].kind).toBe(ts.SyntaxKind.VariableStatement);
 		expect(nodes[2].kind).toBe(ts.SyntaxKind.ExportAssignment);
 		expect(printedCode.includes("const NotionConfig")).toBe(true);
+	});
+
+	test("Zod schema field keys are the auth and list property names for config modules", () => {
+		expect(new Set(NOTION_CONFIG_FIELD_KEYS)).toEqual(
+			new Set(["auth", "databases", "agents"]),
+		);
+	});
+
+	test("renders a literal TypeScript config module (AST, same shape as init template)", () => {
+		const code = renderLiteralNotionConfigModule({
+			isTS: true,
+			config: {
+				auth: "fix-token",
+				databases: [MOCK_DATA_SOURCE_ID],
+				agents: ["agent-1"],
+			},
+		});
+		expect(code).toContain("const auth = ");
+		expect(code).toContain('"fix-token"');
+		expect(code).toContain("const NotionConfig = ");
+		expect(code).toContain("export default NotionConfig");
+		expect(code).not.toContain("process.env.NOTION_KEY");
+		const nodes = buildLiteralNotionConfigModuleAst({
+			isTS: true,
+			config: {
+				auth: "x",
+				databases: [],
+				agents: [],
+			},
+		});
+		expect(nodes).toHaveLength(3);
 	});
 
 	// Checks fixture scenarios patch config lists for append and replace behavior.

--- a/tests/runtime/config/load-config.contract.test.ts
+++ b/tests/runtime/config/load-config.contract.test.ts
@@ -4,6 +4,7 @@ import {
 	getNotionConfig,
 	loadConfig,
 } from "../../../src/config/loadConfig";
+import { createConfigTemplate } from "../../../src/config/init";
 import { CODEGEN_EMIT_PATHS } from "../../helpers/codegen-file-names";
 import {
 	MOCK_DATA_SOURCE_ID,
@@ -58,19 +59,15 @@ describe("config loading contracts", () => {
 		});
 	});
 
-	test("loadConfig parses a valid TypeScript config template under Node", async () => {
+	test("loadConfig parses the generated JS-compatible notion.config.ts template under Node", async () => {
 		const workspacePath = createTempWorkspace("config-load-valid-ts-");
 		const configPath = writeWorkspaceFile({
 			workspacePath,
 			relativePath: CODEGEN_EMIT_PATHS.notionConfigTs,
-			content: [
-				"const auth = process.env.NOTION_KEY || 'token-123';",
-				"export default {",
-				"  auth,",
-				`  databases: ['${MOCK_DATA_SOURCE_ID}'],`,
-				"  agents: ['agent-1'],",
-				"};",
-			].join("\n"),
+			content: createConfigTemplate(true)
+				.replace('"your-notion-api-key-here"', '"token-123"')
+				.replace("databases: []", `databases: ['${MOCK_DATA_SOURCE_ID}']`)
+				.replace("agents: []", "agents: ['agent-1']"),
 		});
 
 		const config = await loadConfig(configPath);
@@ -79,6 +76,31 @@ describe("config loading contracts", () => {
 			databases: [MOCK_DATA_SOURCE_ID],
 			agents: ["agent-1"],
 		});
+	});
+
+	test("loadConfig rejects notion.config.ts files that require real TypeScript transpilation", async () => {
+		const workspacePath = createTempWorkspace("config-load-invalid-ts-syntax-");
+		const configPath = writeWorkspaceFile({
+			workspacePath,
+			relativePath: CODEGEN_EMIT_PATHS.notionConfigTs,
+			content: [
+				"type NotionConfig = {",
+				"  auth: string;",
+				"  databases: string[];",
+				"  agents: string[];",
+				"};",
+				"const config: NotionConfig = {",
+				"  auth: 'token-123',",
+				`  databases: ['${MOCK_DATA_SOURCE_ID}'],`,
+				"  agents: [],",
+				"};",
+				"export default config;",
+			].join("\n"),
+		});
+
+		await expect(loadConfig(configPath)).rejects.toThrow(
+			"JS-compatible notion.config.ts files",
+		);
 	});
 
 	test("loadConfig rejects invalid config shapes with stable messages", async () => {
@@ -262,7 +284,7 @@ describe("config loading contracts", () => {
 		expect(config.agents).toEqual(["agent-1"]);
 	});
 
-	test("getNotionConfig loads .env before importing notion.config", async () => {
+	test("getNotionConfig loads .env before importing the generated notion.config.ts template", async () => {
 		const workspacePath = createTempWorkspace("config-dotenv-module-");
 		writeWorkspaceFile({
 			workspacePath,
@@ -272,21 +294,14 @@ describe("config loading contracts", () => {
 		writeWorkspaceFile({
 			workspacePath,
 			relativePath: CODEGEN_EMIT_PATHS.notionConfigTs,
-			content: [
-				"const auth = process.env.NOTION_KEY || 'fallback-placeholder';",
-				"export default {",
-				"  auth,",
-				`  databases: ['${MOCK_DATA_SOURCE_ID}'],`,
-				"  agents: [],",
-				"};",
-			].join("\n"),
+			content: createConfigTemplate(true),
 		});
 		process.chdir(workspacePath);
 		delete process.env.NOTION_KEY;
 
 		const config = await getNotionConfig();
 		expect(config.auth).toBe("dotenv-module-token");
-		expect(config.databases).toEqual([MOCK_DATA_SOURCE_ID]);
+		expect(config.databases).toEqual([]);
 		expect(config.agents).toEqual([]);
 	});
 });

--- a/tests/runtime/config/load-config.contract.test.ts
+++ b/tests/runtime/config/load-config.contract.test.ts
@@ -4,6 +4,7 @@ import {
 	getNotionConfig,
 	loadConfig,
 } from "../../../src/config/loadConfig";
+import { renderLiteralNotionConfigModule } from "../../../src/ast/shared/emit/config-emitter";
 import { createConfigTemplate } from "../../../src/config/init";
 import { CODEGEN_EMIT_PATHS } from "../../helpers/codegen-file-names";
 import {
@@ -59,15 +60,19 @@ describe("config loading contracts", () => {
 		});
 	});
 
-	test("loadConfig parses the generated JS-compatible notion.config.ts template under Node", async () => {
+	test("loadConfig parses the init notion.config.ts template (imported as JS-compatible ESM when ext is .ts)", async () => {
 		const workspacePath = createTempWorkspace("config-load-valid-ts-");
 		const configPath = writeWorkspaceFile({
 			workspacePath,
 			relativePath: CODEGEN_EMIT_PATHS.notionConfigTs,
-			content: createConfigTemplate(true)
-				.replace('"your-notion-api-key-here"', '"token-123"')
-				.replace("databases: []", `databases: ['${MOCK_DATA_SOURCE_ID}']`)
-				.replace("agents: []", "agents: ['agent-1']"),
+			content: renderLiteralNotionConfigModule({
+				config: {
+					auth: "token-123",
+					databases: [MOCK_DATA_SOURCE_ID],
+					agents: ["agent-1"],
+				},
+				isTS: true,
+			}),
 		});
 
 		const config = await loadConfig(configPath);

--- a/tests/runtime/config/load-config.contract.test.ts
+++ b/tests/runtime/config/load-config.contract.test.ts
@@ -58,6 +58,29 @@ describe("config loading contracts", () => {
 		});
 	});
 
+	test("loadConfig parses a valid TypeScript config template under Node", async () => {
+		const workspacePath = createTempWorkspace("config-load-valid-ts-");
+		const configPath = writeWorkspaceFile({
+			workspacePath,
+			relativePath: CODEGEN_EMIT_PATHS.notionConfigTs,
+			content: [
+				"const auth = process.env.NOTION_KEY || 'token-123';",
+				"export default {",
+				"  auth,",
+				`  databases: ['${MOCK_DATA_SOURCE_ID}'],`,
+				"  agents: ['agent-1'],",
+				"};",
+			].join("\n"),
+		});
+
+		const config = await loadConfig(configPath);
+		expect(config).toEqual({
+			auth: "token-123",
+			databases: [MOCK_DATA_SOURCE_ID],
+			agents: ["agent-1"],
+		});
+	});
+
 	test("loadConfig rejects invalid config shapes with stable messages", async () => {
 		const workspacePath = createTempWorkspace("config-load-invalid-");
 		const configPath = writeWorkspaceFile({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
 			"strict": true,
 			"baseUrl": "src",
 			"paths": {
-				"@haustle/notion-orm": ["index.ts"]
+				"@haustle/notion-orm": ["index.ts"],
+				"@notionhq/agents-client": ["client/agent/notionhq-agents-client.d.ts"]
 			},
 			"noImplicitAny": true,
 			"declaration": true,

--- a/website/content/index.mdx
+++ b/website/content/index.mdx
@@ -200,7 +200,10 @@ await notion.databases.books.deleteMany({
 
 ### Stream large result sets
 
+With the usual `await findMany(...)`, **`size` only bounds a single Notion query**: you get one response’s worth of rows (at most `size`), and nothing else is fetched even if more pages match. **`stream`** is different: that number is how many rows to request **per Notion call**. When a response says there are more pages, the library **fetches the next page for you** (using the cursor), over and over, until everything matching your filter has been returned. Your `for await` loop then sees **one row per iteration**—the full result set, in order, without loading it all into one big array and without hand-writing pagination (compare [cursor pagination](#cursor-pagination), where you pass each `nextCursor` yourself). Full arg details: [`findMany`](/api-reference#findmany).
+
 ```ts
+// Notion is queried in chunks of 50; the loop runs once per matching row, not just the first chunk
 for await (const book of notion.databases.books.findMany({ stream: 50 })) {
   console.log(book.bookName);
 }

--- a/website/content/index.mdx
+++ b/website/content/index.mdx
@@ -200,7 +200,7 @@ await notion.databases.books.deleteMany({
 
 ### Stream large result sets
 
-With the usual `await findMany(...)`, **`size` only bounds a single Notion query**: you get one response’s worth of rows (at most `size`), and nothing else is fetched even if more pages match. **`stream`** is different: that number is how many rows to request **per Notion call**. When a response says there are more pages, the library **fetches the next page for you** (using the cursor), over and over, until everything matching your filter has been returned. Your `for await` loop then sees **one row per iteration**—the full result set, in order, without loading it all into one big array and without hand-writing pagination (compare [cursor pagination](#cursor-pagination), where you pass each `nextCursor` yourself). Full arg details: [`findMany`](/api-reference#findmany).
+The usual `await findMany` uses `size` for **one** request only (no follow-up fetches). **`stream: n`** means **n rows per Notion call**, with cursors followed automatically; `for await` then yields **one row at a time** for the full match—no loading everything into an array, and no hand-rolled `nextCursor` (see [cursor pagination](#cursor-pagination)). [`findMany`](/api-reference#findmany).
 
 ```ts
 // Notion is queried in chunks of 50; the loop runs once per matching row, not just the first chunk


### PR DESCRIPTION
## Description

Previously, plain Node could not `import()` a `notion.config.ts` file, so consumers using the init TypeScript template failed at runtime unless they used Bun or precompiled the config. This change loads JS-compatible `notion.config.ts` by mirroring it to a temporary `.mjs` next to the config, documents the contract, tightens config codegen/tests, and ships **0.0.48**.

**Key changes:**

- **Load `notion.config.ts` on plain Node** — `loadJsCompatibleTsConfig` reads the file, writes a short-lived `*.runtime-<uuid>.mjs` beside it, `import()`s that URL, and deletes the temp file; only the `notion init --ts` JS-compatible template is supported, not arbitrary TypeScript.
- **Refine `loadConfig` errors** — single wrap in `loadUserConfig` for non-TS paths; TS load failures surface a message that points at JS-compatible init output.
- **Add `NOTION_CONFIG_FIELD_KEYS`** — derived from `notionConfigSchema.shape` via `objectKeys` in `types.ts` for typed key coverage in tests and callers.
- **Emit literal `notion.config` modules from `NotionConfigType`** — `buildLiteralNotionConfigModuleAst` / `renderLiteralNotionConfigModule` plus `buildNotionConfigModuleAst` unifies template vs literal AST; config-emitter tests cover the literal path and golden alignment.
- **Document `findMany` `stream` vs `size`** — shorter copy on the site overview.
- **Bump package to `0.0.48`** — `package.json` version for release.
- **Tooling** — `knip` / `tsconfig` tweaks tied to the above.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

`bun test` in the ORM repo (config-emitter, `load-config.contract`, CLI/codegen). Consumer tarball smoke (e.g. `orm-testing` + `bun run coffee-shop`) is recommended if you want an extra check outside CI.
